### PR TITLE
Translation fix for portuguese

### DIFF
--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -6,6 +6,6 @@
 <section class="project-form">
   <%= simple_form_for @project, :url => submissions_url, :html => { :multipart => true } do |form| %>
     <%= render 'form', :project => @project, :form => form %>
-    <%= submit_tag "Apply" %>
+    <%= submit_tag t ".apply" %>
   <% end %>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,7 @@ en:
     new:
       title: Are you ready to get Awesome!?
       description: Just fill out the application below with information about your self and the details of your project.
+      apply: Apply
     form:
       save: Save
       image-notes: The first image is set as the cover image. Images will be resized to %{dimensions} pixels.

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -112,6 +112,7 @@ pt:
     new:
       title: Você está pronto para ser Irado!?
       description: Apenas preencha o formulário abaixo com seus dados e detalhes do seu projeto.
+      apply: "Enviar"
     form:
       save: Salvar
       image-notes: A primeira imagem é usada como imagem de capa. As imagens serão redimensionadas para %{dimensions} pixels.
@@ -197,7 +198,7 @@ pt:
         chapter_id: Selecione o capítulo ao qual quer enviar sua proposta
         rss_feed_url: URL de RSS do projeto
         about_me: Fale-nos um pouco sobre você
-        about_project: Qual é o seu projeto, afinal?
+        about_project: Fale sobre seu projeto incrível!
         use_for_money: Como você vai usar o dinheiro?
       chapter:
         name: Nome
@@ -224,11 +225,11 @@ pt:
         submit: Enviar
         user_image: Imagem do Usuário
       hints:
-      project:
-        funded_description: Only visible on the funded project page
-        rss_feed_url: Links para posts deste feed será exibido na página do projeto financiado
-      user:
-        user_image: Set your user image at <a href="https://en.gravatar.com/site/signup/%{email}" target="_blank">gravatar.com</a> using your email address above
+        project:
+          funded_description: Visível apenas na página do projeto fundado.
+          rss_feed_url: Links para posts deste feed será exibido na página do projeto financiado
+        user:
+          user_image: Defina sua imagem em <a href="https://en.gravatar.com/site/signup/%{email}" target="_blank">gravatar.com</a> usando seu endereço de e-mail informado acima
   activerecord:
     errors:
       models:


### PR DESCRIPTION
Hey Jesse,

this is Ana's friend from Awesome Rio. I fixed the problem on the portuguese translations for the submit project page. I also created a new translation for the "apply" button, both in portuguese and english since the caption was not translated.

The original pt.yml file was using CRLF instead of just LF, ergo the huge number of deletions.

If you see something that's not ok, let me know.

Tks!
