### PR TITLE
Restrict image types to png, jpg and gif with server-side validation

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -11,4 +11,6 @@ class Photo < ActiveRecord::Base
                     :default_url => "/assets/no-image-:style.png"
 
   attr_accessible :image
+
+  validates_attachment :image, content_type: {'image/jpeg', 'image/jpg', 'image/png', 'image/gif'}, size: {in: 0..1000.kilobytes}, message: 'supports jpeg and png files up to 1MB'
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -12,5 +12,5 @@ class Photo < ActiveRecord::Base
 
   attr_accessible :image
 
-  validates_attachment :image, content_type: {'image/jpeg', 'image/jpg', 'image/png', 'image/gif'}, size: {in: 0..1000.kilobytes}, message: 'supports jpeg and png files up to 1MB'
+  validates_attachment :image, content_type: {content_type: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif']}
 end


### PR DESCRIPTION
Using paperclip's validates_attachment to resolve issue https://github.com/awesomefoundation/awesomebits/issues/61 in a more precise manner. 

One issue is that flash messages don't seem to be appearing to tell the user why their application isn't going through if its the wrong type still. 
