### PR TITLE
Ignore gemset file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-gemset
 .bundle
 db/*.sqlite3
 log/*.log


### PR DESCRIPTION
Per the discussion at the summit, ignore the .ruby-gemset file so that individual contributors can manage their local environments as desired.
