### PR TITLE
Remove subheadline from FAQ page

### DIFF
--- a/app/assets/stylesheets/_faq.scss
+++ b/app/assets/stylesheets/_faq.scss
@@ -2,7 +2,6 @@
   @include clearfix();
 
   header {
-    border-bottom: 3px solid rgb(220,220,220);
     margin: 0 auto;
     width: grid-width(12);
 

--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -4,7 +4,6 @@
 <section class="faq-wrapper">
   <header>
     <h1><%= t(".headline") %></h1>
-    <h2><%= t(".sub_headline") %></h2>
   </header>
 
   <section class="faq-answers">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,7 +182,6 @@ en:
     faq:
       title_tag: FAQ
       headline: Frequently Asked Questions
-      sub_headline: Everything you need to know about advancing awesomeness
   simple_form:
     labels:
       project:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -182,7 +182,6 @@ fr:
     faq:
       title_tag: Foire aux Questions
       headline: Foire aux Questions (FAQ)
-      sub_headline: Tout ce que vous devez savoir sur la promotion de ce qu’il y a de génial dans l’univers
   simple_form:
     labels:
       project:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -182,7 +182,6 @@ pt:
     faq:
       title_tag: Perguntas Frequentes
       headline: Informações super iradas
-      sub_headline: Tudo o que você precisa saber sobre tornar irado.
   simple_form:
     labels:
       project:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -182,7 +182,6 @@ ru:
     faq:
       title_tag: Часто задаваемые вопросы
       headline: Невероятно потрясающая информация
-      sub_headline: Всё, что нужно знать о потрясающих идеях.
   simple_form:
     labels:
       project:


### PR DESCRIPTION
As per #109 remove sub-headline from the FAQ page for all languages.