### PR TITLE
Update trustee emails to reference the webmaster email address

### DIFF
--- a/app/views/invitation_mailer/invite_trustee.text.erb
+++ b/app/views/invitation_mailer/invite_trustee.text.erb
@@ -10,6 +10,5 @@ chapter’s website. You’ll also be able to read and create personal
 shortlists for your chapter’s applications. It’ll be a really good time, we
 promise.
 
-If you have any questions or concerns, please contact the Awesome Web team:
-awesome-web@googlegroups.com
-
+If you have any questions about the site, please contact the Awesome Web team:
+webmaster@awesomefoundation.org

--- a/app/views/invitation_mailer/welcome_trustee.text.erb
+++ b/app/views/invitation_mailer/welcome_trustee.text.erb
@@ -16,8 +16,8 @@ that you want to review. If you like a project, you can mark it as
 Dean of your chapter will also be able to view everyone’s shortlists and
 quickly compile a top list for deliberation.
 
-If you have any questions, please contact the Awesome Web team:
-awesome-web@googlegroups.com
+If you have any questions about the site, please contact the Awesome Web team:
+webmaster@awesomefoundation.org
 
 Thanks!
 Awesome Web Team


### PR DESCRIPTION
It turns out the awesome-web@googlegroups.com email address is private, so that's a terrible place to direct people's questions.