### PR TITLE
Add capybara-screenshot gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :test do
   gem "capybara"
   gem "database_cleaner"
   gem "capybara-webkit", "~> 1.3.0"
+  gem 'capybara-screenshot'
   gem "factory_girl_rails"
   gem "faker"
   gem "bourne"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-screenshot (1.0.11)
+      capybara (>= 1.0, < 3)
+      launchy
     capybara-webkit (1.3.0)
       capybara (>= 2.0.2, < 2.5.0)
       json
@@ -385,6 +388,7 @@ DEPENDENCIES
   bourne
   byebug
   capybara
+  capybara-screenshot
   capybara-webkit (~> 1.3.0)
   clearance (~> 0.16.2)
   coffee-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'sucker_punch/testing/inline'
 
 DatabaseCleaner.strategy = :truncation
 Capybara.javascript_driver = :webkit
+require 'capybara-screenshot/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
In debugging an issue in #202, I found the capybara-screenshot gem to be extremely useful. The gem captures the HTML file of the page failing the spec, making it waaaaay easier to see what's wrong. (Seeing it in a browser made it easy to see that a link was broken because of a missing translation.)

If everyone's amenable I'd suggest we add this to the repo. That way when some future changes/gem upgrades that break the features, the developer will have this at their fingertips.