### PR TITLE
Remove therubyracer gem and add the nodejs runtime to the web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.1.7
 
 RUN apt-get update -qq \
-  && apt-get install -y build-essential libpq-dev libqtwebkit-dev qt4-qmake
+  && apt-get install -y build-essential libpq-dev libqtwebkit-dev qt4-qmake nodejs
 
 WORKDIR /app
 ADD Gemfile /app/Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'sucker_punch', '~> 1.0'
 gem 's3_file_field'
 gem 'html_pipeline_rails'
 gem 'magnific-popup-rails'
-gem 'therubyracer'
 
 group :development, :test do
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,6 @@ GEM
     json_pure (1.8.1)
     launchy (2.1.0)
       addressable (~> 2.2.6)
-    libv8 (3.16.14.11)
     magnific-popup-rails (0.9.9.1)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -295,7 +294,6 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (2.1.1)
-    ref (2.0.0)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -355,9 +353,6 @@ GEM
       json
     texticle (2.0.3)
       activerecord (~> 3.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
-      ref
     thin (1.3.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -431,7 +426,6 @@ DEPENDENCIES
   sucker_punch (~> 1.0)
   tddium
   texticle (~> 2.0)
-  therubyracer
   thin
   timecop
   turnip


### PR DESCRIPTION
Remove gem that was added in #203 (not needed and Heroku recommends not including it). Installing the `nodejs` package in the web container instead, which can be used by the coffeescript compiler.