### PR TITLE
Add NYT article to the about page

### DIFF
--- a/app/views/locales/_about_us.en.md
+++ b/app/views/locales/_about_us.en.md
@@ -10,7 +10,7 @@ Every chapter interprets "awesome" for itself. As such, awesome projects include
 
 ## Does anyone else know about this?
 
-We've had lots of great media coverage since our humble beginnings in 2009. Some of our favourite pieces have been from [BBC](http://www.bbc.com/news/magazine-23469438), [CBC](http://www.cbc.ca/player/Radio/Local+Shows/Ontario/In+Town+and+Out/ID/2509176460/), [WGBH](http://blogs.wgbh.org/innovation-hub/2014/6/13/giving-money-away-step-aside-bill-gates/), [Chronicle of Philanthropy](http://philanthropy.com/article/A-Quirky-Grass-Roots-Effort/131683/), and [The Boston Globe](http://www.boston.com/business/technology/articles/2011/10/10/tiny_grants_keep_awesome_ideas_coming/).
+We've had lots of great media coverage since our humble beginnings in 2009. Some of our favourite pieces have been from [The New York Times](http://www.nytimes.com/2015/07/19/nyregion/awesome-foundation-new-york-chapter-invests-in-awesome-ideas.html), [BBC](http://www.bbc.com/news/magazine-23469438), [CBC](http://www.cbc.ca/player/Radio/Local+Shows/Ontario/In+Town+and+Out/ID/2509176460/), [WGBH](http://blogs.wgbh.org/innovation-hub/2014/6/13/giving-money-away-step-aside-bill-gates/), [Chronicle of Philanthropy](http://philanthropy.com/article/A-Quirky-Grass-Roots-Effort/131683/), and [The Boston Globe](http://www.boston.com/business/technology/articles/2011/10/10/tiny_grants_keep_awesome_ideas_coming/).
 
 ## How does it all work? Which chapter should I apply to? When will I hear back?
 

--- a/app/views/locales/_about_us.es.md
+++ b/app/views/locales/_about_us.es.md
@@ -10,7 +10,7 @@ Cada capítulo interpreta "impresionante" por sí mismo.  Como tal, los proyecto
 
 ## ¿Alguien más sabe de esto?
 
-Hemos recibido mucha cobertura buena de los medios desde nuestro humilde comienzo en el 2009.  Algunas de nuestras selecciones favorita han estado en [BBC](http://www.bbc.com/news/magazine-23469438), [CBC](http://www.cbc.ca/player/Radio/Local+Shows/Ontario/In+Town+and+Out/ID/2509176460/), [WGBH](http://blogs.wgbh.org/innovation-hub/2014/6/13/giving-money-away-step-aside-bill-gates/), [Chronicle of Philanthropy](http://philanthropy.com/article/A-Quirky-Grass-Roots-Effort/131683/), y [The Boston Globe](http://www.boston.com/business/technology/articles/2011/10/10/tiny_grants_keep_awesome_ideas_coming/).
+Hemos recibido mucha cobertura buena de los medios desde nuestro humilde comienzo en el 2009.  Algunas de nuestras selecciones favorita han estado en [The New York Times](http://www.nytimes.com/2015/07/19/nyregion/awesome-foundation-new-york-chapter-invests-in-awesome-ideas.html), [BBC](http://www.bbc.com/news/magazine-23469438), [CBC](http://www.cbc.ca/player/Radio/Local+Shows/Ontario/In+Town+and+Out/ID/2509176460/), [WGBH](http://blogs.wgbh.org/innovation-hub/2014/6/13/giving-money-away-step-aside-bill-gates/), [Chronicle of Philanthropy](http://philanthropy.com/article/A-Quirky-Grass-Roots-Effort/131683/), y [The Boston Globe](http://www.boston.com/business/technology/articles/2011/10/10/tiny_grants_keep_awesome_ideas_coming/).
 
 ## ¿Cómo funciona? A qué capítulo debo solicitar? ¿Cuándo me contestarán?
 

--- a/app/views/locales/_about_us.fr.md
+++ b/app/views/locales/_about_us.fr.md
@@ -8,7 +8,7 @@ Chaque branche définit elle-même ce qui est « génial ». C’est pourquoi le
 
 ## Qui est au courant que ça existe ?
 
-Depuis nos modestes débuts en 2009, de nombreux médias se sont intéressés à notre projet. Parmi nos préférées figurent la [BBC](http://www.bbc.com/news/magazine-23469438), [CBC](http://www.cbc.ca/player/Radio/Local+Shows/Ontario/In+Town+and+Out/ID/2509176460/), [WGBH](http://blogs.wgbh.org/innovation-hub/2014/6/13/giving-money-away-step-aside-bill-gates/), [Chronicle of Philanthropy](http://philanthropy.com/article/A-Quirky-Grass-Roots-Effort/131683/), et le [Boston Globe](http://www.boston.com/business/technology/articles/2011/10/10/tiny_grants_keep_awesome_ideas_coming/).
+Depuis nos modestes débuts en 2009, de nombreux médias se sont intéressés à notre projet. Parmi nos préférées figurent la [The New York Times](http://www.nytimes.com/2015/07/19/nyregion/awesome-foundation-new-york-chapter-invests-in-awesome-ideas.html), [BBC](http://www.bbc.com/news/magazine-23469438), [CBC](http://www.cbc.ca/player/Radio/Local+Shows/Ontario/In+Town+and+Out/ID/2509176460/), [WGBH](http://blogs.wgbh.org/innovation-hub/2014/6/13/giving-money-away-step-aside-bill-gates/), [Chronicle of Philanthropy](http://philanthropy.com/article/A-Quirky-Grass-Roots-Effort/131683/), et le [Boston Globe](http://www.boston.com/business/technology/articles/2011/10/10/tiny_grants_keep_awesome_ideas_coming/).
 
 ## Comment est-ce que ça marche ? Auprès de quelle branche postuler ? Quand aurai-je une réponse ?
 

--- a/app/views/locales/_about_us.pt.md
+++ b/app/views/locales/_about_us.pt.md
@@ -10,7 +10,7 @@ Cada capítulo tem sua própria interpretação do que é irado. Dessa forma, pr
 
 ## Quem mais sabe sobre nós?
 
-Nós tivemos diversas coberturas de mídia desde a nossa humilde fundação em 2009. Algumas das nossas reportagens favoritas foram: [BBC](http://www.bbc.com/news/magazine-23469438), [CBC](http://www.cbc.ca/player/Radio/Local+Shows/Ontario/In+Town+and+Out/ID/2509176460/), [WGBH](http://blogs.wgbh.org/innovation-hub/2014/6/13/giving-money-away-step-aside-bill-gates/), [Chronicle of Philanthropy](http://philanthropy.com/article/A-Quirky-Grass-Roots-Effort/131683/), and [The Boston Globe](http://www.boston.com/business/technology/articles/2011/10/10/tiny_grants_keep_awesome_ideas_coming/).
+Nós tivemos diversas coberturas de mídia desde a nossa humilde fundação em 2009. Algumas das nossas reportagens favoritas foram: [The New York Times](http://www.nytimes.com/2015/07/19/nyregion/awesome-foundation-new-york-chapter-invests-in-awesome-ideas.html), [BBC](http://www.bbc.com/news/magazine-23469438), [CBC](http://www.cbc.ca/player/Radio/Local+Shows/Ontario/In+Town+and+Out/ID/2509176460/), [WGBH](http://blogs.wgbh.org/innovation-hub/2014/6/13/giving-money-away-step-aside-bill-gates/), [Chronicle of Philanthropy](http://philanthropy.com/article/A-Quirky-Grass-Roots-Effort/131683/), and [The Boston Globe](http://www.boston.com/business/technology/articles/2011/10/10/tiny_grants_keep_awesome_ideas_coming/).
 
 ## Como isso tudo funciona? Pra qual capítulo eu devo mandar meu projeto? Quando eu vou ter uma resposta? 
 


### PR DESCRIPTION
@avicaplan Any reason to not add the NYT article to the About page?