### PR TITLE
Implement very basic blacklisting to block rogue IPs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'sucker_punch', '~> 1.0'
 gem 's3_file_field'
 gem 'html_pipeline_rails'
 gem 'magnific-popup-rails'
+gem 'rack-attack'
 
 group :development, :test do
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,8 @@ GEM
     pry-nav (0.2.1)
       pry (~> 0.9.9)
     rack (1.4.7)
+    rack-attack (4.3.1)
+      rack
     rack-cache (1.2)
       rack (>= 0.4)
     rack-protection (1.5.3)
@@ -412,6 +414,7 @@ DEPENDENCIES
   pg (~> 0.13.2)
   pry
   pry-nav
+  rack-attack
   rails (= 3.2.22)
   rails_12factor
   redcarpet

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ MAGICKLY_HOST=http://localhost:8888
 ```
 
 
+Blacklist
+---------
+
+Very basic blacklisting is implemented using [Rack::Attack](https://github.com/kickstarter/rack-attack).
+To blacklist an IP, simply add the IP address to the BLACKLIST_IPS environment
+variable. Multiple IPs should be comma separated:
+
+```shell
+BLACKLIST_IPS=10.0.0.1,10.0.0.2
+```
+
+
 License
 -------
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,5 +70,8 @@ module Awesomefoundation
 
     # Do not initialize on assets compilation
     config.assets.initialize_on_precompile = false
+
+    # Load middleware
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,0 +1,7 @@
+class Rack::Attack
+  blacklist_ips = ENV['BLACKLIST_IPS'] ? ENV['BLACKLIST_IPS'].split(/,\s*/) : []
+
+  blacklist("blacklisted ips") do |request|
+    blacklist_ips.include? request.ip
+  end
+end


### PR DESCRIPTION
Add the ability to manually blacklist one or more IP addresses just by setting the `BLACKLIST_IPS` environment variable.