### PR TITLE
Fix incorrect translation reference

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -91,7 +91,7 @@ class ProjectsController < ApplicationController
     if params[:hidden_reason].present?
       @project.hide!(params[:hidden_reason], current_user)
     else
-      flash[:notice] = t("hide-reason-required")
+      flash[:notice] = t("flash.projects.hide-reason-required")
     end
     redirect_to chapter_projects_path(@project.chapter_id, anchor: "project#{@project.id}", page: params[:page])
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,8 @@ en:
       thanks: "Thanks for applying!"
     acceptances:
       cannot: "Could not accept the invitation"
+    projects:
+      hide-reason-required: You must supply a reason a to hide a project
   layouts:
     application:
       main-header: The Awesome Foundation
@@ -120,7 +122,6 @@ en:
       unhide: Unhide
       consider-hiding: Not an appropriate grant?
       hide-reason: Why is this not appropriate?
-      hide-reason-required: You must supply a reason a to hide a project!
       hidden-details: "Hidden by %{username} on %{hidden_at} because %{reason}."
       hiding-explanation: "Hiding a project will hide its details from everyone; the title and why it was hidden will still be visible, and it can be easily unhidden."
       unhiding-explanation: "Restore this project so everyone will be able to see it again."


### PR DESCRIPTION
Originally committed in b2750bc89df9ccdb71e71d18929e0513175c12f6