### PR TITLE
When hiding/unhiding a project, redirect to the right place

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -104,7 +104,7 @@ class ProjectsController < ApplicationController
   def unhide
     @project = Project.find(params[:id])
     @project.unhide!
-    redirect_to project_path(@project.id)
+    redirect_to chapter_project_path(@project.chapter, @project)
   end
 
   def destroy

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -88,12 +88,17 @@ class ProjectsController < ApplicationController
 
   def hide
     @project = Project.find(params[:id])
+
     if params[:hidden_reason].present?
       @project.hide!(params[:hidden_reason], current_user)
     else
       flash[:notice] = t("flash.projects.hide-reason-required")
     end
-    redirect_to chapter_projects_path(@project.chapter_id, anchor: "project#{@project.id}", page: params[:page])
+
+    return_to = params[:return_to] ? URI(params[:return_to]) : URI(chapter_projects_path(@project.chapter))
+    return_to.fragment = "project#{@project.id}"
+
+    redirect_to return_to.to_s
   end
 
   def unhide

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -32,7 +32,7 @@
         <%= form_tag hide_project_path(project), method: :put, class: "hide-form" do %>
           <%= t(".hide-reason") %>
           <%= text_field_tag :hidden_reason, "", class: "reason" %>
-          <%= hidden_field_tag :page, params[:page] || 1 %>
+          <%= hidden_field_tag :return_to, request.original_url %>
           <%= submit_tag t(".hide"), class: "hide-action" %>
         <% end %>
         <div class="explanation">

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -156,7 +156,7 @@ describe ProjectsController do
     context "with a legit project" do
       context "with a reason" do
         before :each do
-          put :hide, id: project.id, hidden_reason: reason
+          put :hide, id: project.id, hidden_reason: reason, return_to: chapter_projects_path(project.chapter)
         end
 
         it "hides the project" do
@@ -166,32 +166,32 @@ describe ProjectsController do
         end
 
         it "redirects to the appropriate place in the projects page" do
-          expect(response).to redirect_to(chapter_projects_path(project.chapter_id, anchor: "project#{project.id}"))
+          expect(response).to redirect_to(chapter_projects_path(project.chapter, anchor: "project#{project.id}"))
         end
       end
 
       context "with a reason" do
-        let(:page) { 2 }
+        let(:return_to) { chapter_projects_path(project.chapter, q: project.title) }
 
         it "doesn't hide the project" do
-          put :hide, id: project.id, hidden_reason: "", page: page
+          put :hide, id: project.id, hidden_reason: "", return_to: return_to
           project.reload
           expect(project).not_to be_hidden
         end
 
         it "sets a flash" do
-          put :hide, id: project.id, hidden_reason: "", page: page
+          put :hide, id: project.id, hidden_reason: "", return_to: return_to
           expect(flash[:notice]).not_to be_blank
         end
 
         it "redirects to the appropriate place in the projects page" do
-          put :hide, id: project.id, hidden_reason: "", page: page
-          expect(response).to redirect_to(chapter_projects_path(project.chapter_id, page: page, anchor: "project#{project.id}"))
+          put :hide, id: project.id, hidden_reason: "", return_to: return_to
+          expect(response).to redirect_to(chapter_projects_path(project.chapter, q: project.title, anchor: "project#{project.id}"))
         end
 
         it "defaults to page 1 by default" do
           put :hide, id: project.id, hidden_reason: ""
-          expect(response).to redirect_to(chapter_projects_path(project.chapter_id, anchor: "project#{project.id}"))
+          expect(response).to redirect_to(chapter_projects_path(project.chapter, anchor: "project#{project.id}"))
         end
       end
     end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -222,8 +222,8 @@ describe ProjectsController do
         expect(project).not_to be_hidden
       end
 
-      it "redirects to the appropriate place in the projects page" do
-        expect(response).to redirect_to(project_path(project.id))
+      it "redirects to the project project" do
+        expect(response).to redirect_to(chapter_project_path(project.chapter, project))
       end
     end
   end


### PR DESCRIPTION
* When hiding, redirect to the calling page with all original parameters (if appropriate)
* When unhiding, redirect to the internal project page