### PR TITLE
Remove the ability to toggle between the classic and S3 image uploader

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -43,8 +43,9 @@
 
   <% if s3_uploader_available? %>
     <%= render :partial => "image_form", :locals => { :form => form, :upload_mechanism => :s3 } %>
+  <% else %>
+    <%= render :partial => "image_form", :locals => { :form => form, :upload_mechanism => :classic } %>
   <% end %>
-  <%= render :partial => "image_form", :locals => { :form => form, :upload_mechanism => :classic } %>
 
 </div>
 

--- a/app/views/projects/_image_form.html.erb
+++ b/app/views/projects/_image_form.html.erb
@@ -13,15 +13,4 @@
     </div>
 
     <div><%= t("projects.form.image-notes", :dimensions => Photo::MAIN_DIMENSIONS) %></div>
-
-    <% if s3_uploader_available? %>
-    <div class="toggle-uploader">
-      <% if upload_mechanism == :s3 %>
-        <%= link_to t("projects.form.use-classic-uploader"), params.merge(:uploader => "classic") %>
-      <% else %>
-        <%= link_to t("projects.form.use-default-uploader"), params.merge(:uploader => nil) %>
-      <% end %>
-    </div>
-    <% end %>
-
   </div>


### PR DESCRIPTION
The two versions still exist - the classic uploader will be used if
S3 uploading is not available (they keys haven't been set up, etc).

Closes #209 