### PR TITLE
Hide inactive chapters by default

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -7,7 +7,7 @@ class ChaptersController < ApplicationController
   # everything gets crawled for SEO purposes. This can be rethought
   # in the future if needed.
   def index
-    @chapters = Chapter.visitable.all.sort_by(&CountrySortCriteria.new(COUNTRY_PRIORITY))
+    @chapters = chapter_source.visitable.all.sort_by(&CountrySortCriteria.new(COUNTRY_PRIORITY))
   end
 
   def show
@@ -45,6 +45,14 @@ class ChaptersController < ApplicationController
   def ensure_lowercase_id
     if params[:id].match(/[A-Z]+/)
       redirect_to(:id => params[:id].parameterize, :status => :moved_permanently) && return
+    end
+  end
+
+  def chapter_source
+    if params[:include_inactive]
+      Chapter
+    else
+      Chapter.active
     end
   end
 end

--- a/spec/views/chapters_views_spec.rb
+++ b/spec/views/chapters_views_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'chapters/show' do 
+describe 'chapters/show' do
   let!(:chapter) { FactoryGirl.create(:chapter) }
 
   context 'an active chapter' do
@@ -49,7 +49,7 @@ describe 'chapters/show' do
     rendered.should_not have_selector('section.chapter-projects')
   end
 
-  it 'does not render the trustee section by default' do 
+  it 'does not render the trustee section by default' do
     assign(:chapter, chapter)
     view.stubs(:current_user).returns(nil)
 
@@ -78,7 +78,7 @@ describe 'chapters/show' do
     end
   end
 
-  context 'with trustees' do 
+  context 'with trustees' do
     let!(:dean) { FactoryGirl.create(:user_with_dean_role) }
 
     it 'renders the trustee secton' do
@@ -93,7 +93,7 @@ describe 'chapters/show' do
   context 'with rss feed' do
     before { chapter.update_attribute(:rss_feed_url, 'http://example.com/rss') }
 
-    it 'renders the news section' do 
+    it 'renders the news section' do
       assign(:chapter, chapter)
       view.stubs(:current_user).returns(nil)
 
@@ -104,12 +104,12 @@ describe 'chapters/show' do
   end
 end
 
-describe 'chapters/edit' do 
+describe 'chapters/edit' do
   let(:dean) { FactoryGirl.create(:user_with_dean_role) }
   let(:admin) { FactoryGirl.create(:admin) }
   let(:chapter) { FactoryGirl.create(:chapter) }
 
-  it 'does not display the inactivity checkbox to deans' do 
+  it 'does not display the inactivity checkbox to deans' do
     assign(:chapter, dean.chapters.first)
     view.stubs(:current_user).returns(dean)
 
@@ -118,7 +118,7 @@ describe 'chapters/edit' do
     rendered.should_not have_selector('#chapter_inactive')
   end
 
-  it 'displays the inactivity checkbox to admins' do 
+  it 'displays the inactivity checkbox to admins' do
     assign(:chapter, chapter)
     view.stubs(:current_user).returns(admin)
 


### PR DESCRIPTION
For the two million dollar grant microsite we want to link people to the chapters page, but don't want the presence of inactive chapters to send the wrong message. This PR hides inactive chapters by default, though they can be shown through the `include_inactive` parameter; a future PR can add a link to see inactive chapters.