### PR TITLE
Redirect to submissions_path instead of projects_path

### DIFF
--- a/app/controllers/finalists_controller.rb
+++ b/app/controllers/finalists_controller.rb
@@ -22,7 +22,7 @@ class FinalistsController < ApplicationController
   def must_be_able_to_view_finalists
     unless current_user.admin? || current_user.can_view_finalists_for?(current_chapter)
       flash[:notice] = t("flash.permissions.cannot-view-finalists")
-      redirect_to projects_path
+      redirect_to submissions_path
     end
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -11,7 +11,7 @@ class InvitationsController < ApplicationController
     @invitation.inviter = current_user
     if @invitation.save
       @invitation.send_invitation
-      redirect_to projects_path
+      redirect_to submissions_path
     else
       render :new
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -120,7 +120,7 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     @project.destroy
 
-    redirect_to(projects_path)
+    redirect_to submissions_path
   end
 
   private

--- a/app/controllers/winners_controller.rb
+++ b/app/controllers/winners_controller.rb
@@ -30,7 +30,7 @@ class WinnersController < ApplicationController
   def must_be_able_to_mark_winner
     unless current_user.admin? || current_user.can_mark_winner?(current_project)
       flash[:notice] = t("flash.permissions.cannot-mark-winner")
-      redirect_to projects_path
+      redirect_to submissions_path
     end
   end
 end


### PR DESCRIPTION
When adding /projects.xml we removed projects_path as a route to
view a logged-in user's projects. This will now be submissions_path
with funded_projects_path being the path for public projects.

Bug introduced in 4ebb6083b9eed1a4efbb3df980ab6ca4a916ed2a

Closes #230 