### PR TITLE
Chapter subdomains

### DIFF
--- a/app/assets/stylesheets/_shared-forms.scss
+++ b/app/assets/stylesheets/_shared-forms.scss
@@ -173,11 +173,6 @@ section.chapter-form {
   }
 
   label {
-    &.select {
-      margin-right: 10px;
-      @include inline-block;
-    }
-
     &.boolean {
       @include inline-block;
     }
@@ -190,5 +185,11 @@ section.chapter-form {
 
   input.boolean {
     margin-right: 10px;
+  }
+
+  .hint {
+    margin-top: .5em;
+    display: block;
+    font-style: italic;
   }
 }

--- a/app/controllers/subdomains_controller.rb
+++ b/app/controllers/subdomains_controller.rb
@@ -3,24 +3,31 @@ class SubdomainsController < ApplicationController
 
   def chapter
     if @chapter
-      redirect_to(chapter_url(@chapter.slug, :subdomain => 'www')) and return
+      redirect_to(chapter_url(@chapter.slug, :subdomain => @subdomain)) and return
 
     else
-      redirect_to(root_url(:subdomain => 'www')) and return
+      redirect_to(root_url(:subdomain => @subdomain)) and return
     end
   end
 
   def apply
-    redirect_to(new_submission_url(:subdomain => 'www', :chapter => @chapter)) and return
+    redirect_to(new_submission_url(:subdomain => @subdomain, :chapter => @chapter)) and return
   end
 
   protected
 
   def find_chapter
-    @chapter = Chapter.find(request.subdomain)
-    I18n.locale = @chapter.locale
+    subdomains = request.subdomains
+    subdomain  = subdomains.shift
 
-  rescue ActiveRecord::RecordNotFound
-    @chapter = nil
+    begin
+      @chapter = Chapter.find(subdomain)
+      I18n.locale = @chapter.locale
+
+    rescue ActiveRecord::RecordNotFound
+      @chapter = nil
+    end
+
+    @subdomain = subdomains.unshift("www").join(".")
   end
 end

--- a/app/controllers/subdomains_controller.rb
+++ b/app/controllers/subdomains_controller.rb
@@ -1,0 +1,26 @@
+class SubdomainsController < ApplicationController
+  before_filter :find_chapter
+
+  def chapter
+    if @chapter
+      redirect_to(chapter_url(@chapter.slug, :subdomain => 'www')) and return
+
+    else
+      redirect_to(root_url(:subdomain => 'www')) and return
+    end
+  end
+
+  def apply
+    redirect_to(new_submission_url(:subdomain => 'www', :chapter => @chapter)) and return
+  end
+
+  protected
+
+  def find_chapter
+    @chapter = Chapter.find(request.subdomain)
+    I18n.locale = @chapter.locale
+
+  rescue ActiveRecord::RecordNotFound
+    @chapter = nil
+  end
+end

--- a/app/extras/subdomain_constraint.rb
+++ b/app/extras/subdomain_constraint.rb
@@ -1,7 +1,7 @@
 class SubdomainConstraint
   def self.matches?(request)
-    case request.subdomain
-    when 'www', '', nil
+    case request.subdomains.first
+    when 'www', '', nil, 'staging'
       false
     else
       true

--- a/app/extras/subdomain_constraint.rb
+++ b/app/extras/subdomain_constraint.rb
@@ -1,0 +1,10 @@
+class SubdomainConstraint
+  def self.matches?(request)
+    case request.subdomain
+    when 'www', '', nil
+      false
+    else
+      true
+    end
+  end
+end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -20,7 +20,7 @@ class Chapter < ActiveRecord::Base
 
   attr_accessible :name, :twitter_url, :facebook_url, :blog_url, :rss_feed_url, :description,
                   :country, :extra_question_1, :extra_question_2, :extra_question_3, :slug,
-                  :email_address, :time_zone, :inactive
+                  :email_address, :time_zone, :inactive, :locale
 
   def should_generate_new_friendly_id?
     slug.blank?

--- a/app/views/chapters/_form.html.erb
+++ b/app/views/chapters/_form.html.erb
@@ -15,6 +15,7 @@
   <%= form.input :description %>
   <%= form.input :country, :priority => COUNTRY_PRIORITY %>
   <%= form.input :time_zone %>
+  <%= form.input :locale, :collection => I18n.available_locales, :include_blank => false %>
   <%= form.input :extra_question_1 %>
   <%= form.input :extra_question_2 %>
   <%= form.input :extra_question_3 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,6 +228,7 @@ en:
         extra_question_3: Extra question 3
         inactive: This chapter is inactive
         submit: Submit
+        locale: Redirect locale
       user:
         first_name: First name
         last_name: Last name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Awesomefoundation::Application.routes.draw do
+  constraints(SubdomainConstraint) do
+    match "/apply" => "subdomains#apply"
+    match "*url"   => "subdomains#chapter"
+    match "/"      => "subdomains#chapter"
+  end
+
   match "/blog/contact/" => redirect("/en/contact")
   match "/blog/about/"   => redirect("/en/about_us")
   match "/blog"          => redirect("http://blog.awesomefoundation.org")

--- a/db/migrate/20160721212739_add_chapter_locale.rb
+++ b/db/migrate/20160721212739_add_chapter_locale.rb
@@ -1,0 +1,5 @@
+class AddChapterLocale < ActiveRecord::Migration
+  def change
+    add_column :chapters, :locale, :string, :null => false, :default => "en"
+  end
+end

--- a/spec/controllers/subdomains_controller_spec.rb
+++ b/spec/controllers/subdomains_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe SubdomainsController do
+
+  context 'with no subdomain' do
+    it { should route(:get, "http://test.host").to(:controller => "home", :action => "index") }
+  end
+
+  context 'with www subdomain' do
+    it { should route(:get, "http://www.test.host").to(:controller => "home", :action => "index") }
+  end
+
+  context 'with chapter subdomain' do
+    it { should route(:get, "http://subdomain.test.host").to(:controller => "subdomains", :action => "chapter") }
+    it { should route(:get, "http://subdomain.test.host/apply").to(:controller => "subdomains", :action => "apply") }
+
+    context 'for a valid chapter' do
+      let!(:chapter) { FactoryGirl.create(:chapter, :country => "United States", :locale => "es") }
+
+      before do
+        @request.host = "#{chapter.slug}.test.host"
+        get :chapter
+      end
+
+      it { should redirect_to("http://www.test.host/#{chapter.locale}/chapters/#{chapter.slug}") }
+    end
+
+    context 'for an invalid chapter' do
+      before do
+        @request.host = "invalid.test.host"
+        get :chapter
+      end
+
+      it { should redirect_to("http://www.test.host/#{I18n.default_locale}") }
+    end
+  end
+end


### PR DESCRIPTION
Handle `<slug>.awesomefoundation.org` and `<slug>.awesomefoundation.org/apply` redirects.

Closes #235 