### PR TITLE
Bump rails to 3.2.22.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 ruby '2.1.7'
 
-gem 'rails', '3.2.22.2'
+gem 'rails', '3.2.22.3'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ GEM
   remote: http://rubygems.org/
   specs:
     CFPropertyList (2.3.1)
-    actionmailer (3.2.22.2)
-      actionpack (= 3.2.22.2)
+    actionmailer (3.2.22.3)
+      actionpack (= 3.2.22.3)
       mail (~> 2.5.4)
-    actionpack (3.2.22.2)
-      activemodel (= 3.2.22.2)
-      activesupport (= 3.2.22.2)
+    actionpack (3.2.22.3)
+      activemodel (= 3.2.22.3)
+      activesupport (= 3.2.22.3)
       builder (~> 3.0.0)
       erubis (~> 2.7.0)
       journey (~> 1.0.4)
@@ -15,18 +15,18 @@ GEM
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
       sprockets (~> 2.2.1)
-    activemodel (3.2.22.2)
-      activesupport (= 3.2.22.2)
+    activemodel (3.2.22.3)
+      activesupport (= 3.2.22.3)
       builder (~> 3.0.0)
-    activerecord (3.2.22.2)
-      activemodel (= 3.2.22.2)
-      activesupport (= 3.2.22.2)
+    activerecord (3.2.22.3)
+      activemodel (= 3.2.22.3)
+      activesupport (= 3.2.22.3)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activeresource (3.2.22.2)
-      activemodel (= 3.2.22.2)
-      activesupport (= 3.2.22.2)
-    activesupport (3.2.22.2)
+    activeresource (3.2.22.3)
+      activemodel (= 3.2.22.3)
+      activesupport (= 3.2.22.3)
+    activesupport (3.2.22.3)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.2.8)
@@ -236,7 +236,7 @@ GEM
     mime-types (1.25.1)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multi_xml (0.5.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -272,22 +272,22 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (3.2.22.2)
-      actionmailer (= 3.2.22.2)
-      actionpack (= 3.2.22.2)
-      activerecord (= 3.2.22.2)
-      activeresource (= 3.2.22.2)
-      activesupport (= 3.2.22.2)
+    rails (3.2.22.3)
+      actionmailer (= 3.2.22.3)
+      actionpack (= 3.2.22.3)
+      activerecord (= 3.2.22.3)
+      activeresource (= 3.2.22.3)
+      activesupport (= 3.2.22.3)
       bundler (~> 1.0)
-      railties (= 3.2.22.2)
+      railties (= 3.2.22.3)
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
     rails_serve_static_assets (0.0.2)
     rails_stdout_logging (0.0.3)
-    railties (3.2.22.2)
-      actionpack (= 3.2.22.2)
-      activesupport (= 3.2.22.2)
+    railties (3.2.22.3)
+      actionpack (= 3.2.22.3)
+      activesupport (= 3.2.22.3)
       rack-ssl (~> 1.3.2)
       rake (>= 0.8.7)
       rdoc (~> 3.4)
@@ -369,7 +369,7 @@ GEM
     turnip (1.2.2)
       gherkin (>= 2.5)
       rspec (>= 2.0, < 4.0)
-    tzinfo (0.3.46)
+    tzinfo (0.3.51)
     uglifier (1.2.4)
       execjs (>= 0.3.0)
       multi_json (>= 1.0.2)
@@ -415,7 +415,7 @@ DEPENDENCIES
   pry
   pry-nav
   rack-attack
-  rails (= 3.2.22.2)
+  rails (= 3.2.22.3)
   rails_12factor
   redcarpet
   rspec-rails
@@ -435,5 +435,8 @@ DEPENDENCIES
   uglifier
   will_paginate (~> 3.0.3)
 
+RUBY VERSION
+   ruby 2.1.7p400
+
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,4 +25,13 @@ RSpec.configure do |config|
   config.before(:each){ FactoryGirl.create(:chapter, :name => "Any") }
   config.before(:each){ ActionMailer::Base.deliveries.clear }
   config.include(Paperclip::Shoulda::Matchers)
+
+  # TODO Rails 3.2.22.3 introduced a change that makes this required
+  # for getting view tests to pass. When upgrading rspec or
+  # Rails to a future version, see if this is still required.
+  config.before(:suite, :type => :view) do
+    class ActionView::Helpers::InstanceTag
+      include ActionView::Helpers::OutputSafetyHelper
+    end
+  end
 end


### PR DESCRIPTION
http://weblog.rubyonrails.org/2016/8/11/Rails-5-0-0-1-4-2-7-2-and-3-2-22-3-have-been-released/