### PR TITLE
Fix safe_join error introduced in 66721e7d8619feb

### DIFF
--- a/config/initializers/safe_join_fix.rb
+++ b/config/initializers/safe_join_fix.rb
@@ -1,0 +1,5 @@
+# TODO Rails 3.2.22.3 introduced a change that makes this required.
+# When upgrading Rails, see if this is still required.
+class ActionView::Helpers::InstanceTag
+  include ActionView::Helpers::OutputSafetyHelper
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,13 +25,4 @@ RSpec.configure do |config|
   config.before(:each){ FactoryGirl.create(:chapter, :name => "Any") }
   config.before(:each){ ActionMailer::Base.deliveries.clear }
   config.include(Paperclip::Shoulda::Matchers)
-
-  # TODO Rails 3.2.22.3 introduced a change that makes this required
-  # for getting view tests to pass. When upgrading rspec or
-  # Rails to a future version, see if this is still required.
-  config.before(:suite, :type => :view) do
-    class ActionView::Helpers::InstanceTag
-      include ActionView::Helpers::OutputSafetyHelper
-    end
-  end
 end


### PR DESCRIPTION
For some reason, 3.2.22.3 introduces a bug where calls to safe_join fail.
Including the module that contains the safe_join call in the InstanceTag
module seems to fix this.