### PR TITLE
Trying to accept an invitation without including a password no longer crashes

### DIFF
--- a/app/extras/user_factory.rb
+++ b/app/extras/user_factory.rb
@@ -1,4 +1,6 @@
 class UserFactory
+  attr_accessor :errors
+
   def initialize(attributes)
     @attributes = attributes
   end
@@ -9,10 +11,11 @@ class UserFactory
         user.save! && chapter.save! && role.save! && user
       end
     rescue ActiveRecord::ActiveRecordError => e
+      self.errors = e.record.errors
       Rails.logger.error("Cannot accept invitation: #{e.message}")
-      Rails.logger.error("User: #{factory.user.errors.full_messages.to_sentence}") unless factory.user.valid?
-      Rails.logger.error("Chapter: #{factory.chapter.errors.full_messages.to_sentence}") unless factory.chapter.valid?
-      Rails.logger.error("Role: #{factory.role.errors.full_messages.to_sentence}") unless factory.role.valid?
+      Rails.logger.error("User: #{user.errors.full_messages.to_sentence}") unless user.valid?
+      Rails.logger.error("Chapter: #{chapter.errors.full_messages.to_sentence}") unless chapter.valid?
+      Rails.logger.error("Role: #{role.errors.full_messages.to_sentence}") unless role.valid?
       false
     end
   end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -29,6 +29,13 @@ class Invitation < ActiveRecord::Base
       self.invitee = factory.user
       self.accepted = true
       self.save
+    else
+      unless factory.errors.blank?
+        factory.errors.each do |key, error|
+          self.errors[key] = error
+        end
+      end
+      false
     end
   end
 

--- a/app/views/acceptances/new.html.erb
+++ b/app/views/acceptances/new.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for @invitation, :url => invitation_acceptances_path(@invitation), :method => :post do |form| %>
-  <%= form.input :first_name %>
-  <%= form.input :last_name %>
-  <%= form.input :password %>
+  <%= form.input :first_name, :required => true %>
+  <%= form.input :last_name, :required => true %>
+  <%= form.input :password, :required => true %>
   <%= submit_tag "Accept the invitation!" %>
 <% end %>

--- a/spec/controllers/acceptances_controller_spec.rb
+++ b/spec/controllers/acceptances_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe AcceptancesController do
+  let(:invitation) { FactoryGirl.create(:invitation) }
+
+  context 'not logged in' do
+    context 'GET to #new' do
+      before do
+        get :new, :invitation_id => invitation.id
+      end
+
+      it { should respond_with(:success) }
+    end
+
+    context 'accepting with password' do
+      before do
+        post :create, :invitation_id => invitation.id, :invitation => {}
+      end
+
+      it { should respond_with(:success) }
+      it { should render_template('new') }
+      it { expect(flash[:notice]).not_to be_blank }
+    end
+  end
+end

--- a/spec/support/fake_user_factory.rb
+++ b/spec/support/fake_user_factory.rb
@@ -1,4 +1,6 @@
 class FakeUserFactory
+  attr_accessor :errors
+
   def initialize
     @users = []
     @return_value = true


### PR DESCRIPTION
There was a bug in the _logging_ of errors when an invitation was trying to be accepted without a password. Fixed that bug, and also added HTML5 "requires" to the invitation fields to require names and password.