### PR TITLE
In projects atom feed, do not include image enclosures for projects that have none

### DIFF
--- a/app/views/funded_projects/index.xml.builder
+++ b/app/views/funded_projects/index.xml.builder
@@ -7,7 +7,7 @@ atom_feed(language: I18n.locale) do |feed|
       entry.title "#{project.chapter.name} – #{project.title}"
       entry.content(project.funded_description, type: 'html')
 
-      if mime_type = MIME::Types.type_for(project.primary_image.url).first
+      if project.has_images? && mime_type = MIME::Types.type_for(project.primary_image.url).first
         entry.link(href: image_url(project.primary_image.url), rel: 'enclosure', type: mime_type)
       end
 


### PR DESCRIPTION
#261 fixed the problem where the default image didn't have a full url in place which was breaking the twitter/zapier/atom integration, but the real answer is to just not serve an image for projects which do not have an image in the first place.