### PR TITLE
Revert 601dfd93f230 (which removed images from atom feed if a project had no image)

### DIFF
--- a/app/views/funded_projects/index.xml.builder
+++ b/app/views/funded_projects/index.xml.builder
@@ -7,7 +7,7 @@ atom_feed(language: I18n.locale) do |feed|
       entry.title "#{project.chapter.name} – #{project.title}"
       entry.content(project.funded_description, type: 'html')
 
-      if project.has_images? && mime_type = MIME::Types.type_for(project.primary_image.url).first
+      if mime_type = MIME::Types.type_for(project.primary_image.url).first
         entry.link(href: image_url(project.primary_image.url), rel: 'enclosure', type: mime_type)
       end
 


### PR DESCRIPTION
While technically correct, we use some external services that rely on
an image enclosure to be in place, so just for consistency, we'll
always include an image, even if it's the placeholder.