### PR TITLE
Validate completely invalid URLs, including ones that are too long

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -59,6 +59,7 @@ class ProjectsController < ApplicationController
       flash[:thanks] = t("flash.applications.thanks")
       redirect_to root_path
     else
+      flash[:notice] = t("flash.applications.error")
       render :new
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,6 +16,9 @@ class Project < ActiveRecord::Base
 
   before_validation UrlNormalizer.new(:url, :rss_feed_url)
 
+  validates           :url, :rss_feed_url, :url => true, :allow_blank => true
+  validates_length_of :url, :rss_feed_url, :maximum => 255
+
   validates_presence_of :name
   validates_presence_of :title
   validates_presence_of :email

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,0 +1,13 @@
+class UrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    valid = begin
+              URI.parse(value).kind_of?(URI::HTTP)
+            rescue URI::InvalidURIError
+              false
+            end
+
+    unless valid
+      record.errors.add(attribute, options[:message] || :invalid)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
       already-deleted: "Vote has already been deleted"
     applications:
       thanks: "Thanks for applying!"
-      error: There was a problem with your submission
+      error: There was a problem with your application
     acceptances:
       cannot: "Could not accept the invitation"
     projects:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
       already-deleted: "Vote has already been deleted"
     applications:
       thanks: "Thanks for applying!"
+      error: There was a problem with your submission
     acceptances:
       cannot: "Could not accept the invitation"
     projects:
@@ -258,6 +259,10 @@ en:
           attributes:
             slug:
               invalid: must be lowercase and can not contain spaces
+        project:
+          attributes:
+            url:
+              invalid: is not a valid website
   meta:
     description: Forwarding the interest of Awesome in the universe, $1,000 at a time.
   feed:

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -322,6 +322,21 @@ describe Project do
 
       expect(project.url).to eq('')
     end
+
+    it 'rejects an invalid url' do
+      project.url = "url with spaces"
+      expect(project).to_not be_valid
+    end
+
+    it 'rejects an invalid rss url' do
+      project.rss_feed_url = "url with spaces"
+      expect(project).to_not be_valid
+    end
+
+    it 'rejects a url that is too long before url normalization' do
+      project.url = "a" * 255
+      expect(project).to_not be_valid
+    end
   end
 
   describe "#hide! / #hidden?" do


### PR DESCRIPTION
In ef1b914530 we started automatically adding a protocol to project URLs that didn't have one. In some cases, this would push a project URL over the 255 character limit and would cause a database error since we didn't have a model-level validation in place.

This PR adds URL length validation as well as basic validity checking to make sure the URL is actually a URL.