### PR TITLE
When reviewing applications, external links open in new windows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
     rake (10.5.0)
     rdoc (3.12.2)
       json (~> 1.4)
-    redcarpet (2.1.1)
+    redcarpet (3.4.0)
     rollbar (2.15.5)
       multi_json
     rspec (3.6.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,8 +21,8 @@ module ApplicationHelper
                                                :separator => I18n.t("number.separator"))
   end
 
-  def markdown(text)
-    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, :autolink => true, :space_after_headers => true)
+  def markdown(text, renderer_options = {})
+    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(renderer_options), :autolink => true, :space_after_headers => true)
     markdown.render(text).html_safe unless text.nil?
   end
 

--- a/app/views/projects/_project_details.html.erb
+++ b/app/views/projects/_project_details.html.erb
@@ -42,7 +42,7 @@
 
     <% if project.url.present? %>
       <span>
-        · <%= link_to project.url, project.url %>
+        · <%= link_to project.url, project.url, :target => "_blank" %>
       </span>
     <% end %>
   </section>
@@ -60,11 +60,11 @@
     <% end %>
 
     <h3><%= I18n.t(".about-project", scope: "projects.project") %></h3>
-    <%= markdown project.about_project %>
+    <%= markdown project.about_project, :link_attributes => { :target => "_blank" } %>
     <h3><%= I18n.t(".use-for-money", scope: "projects.project") %></h3>
-    <%= markdown project.use_for_money %>
+    <%= markdown project.use_for_money, :link_attributes => { :target => "_blank" } %>
     <h3><%= I18n.t(".about-me", scope: "projects.project") %></h3>
-    <%= markdown project.about_me %>
+    <%= markdown project.about_me, :link_attributes => { :target => "_blank" } %>
 
     <% 1.upto(Chapter::EXTRA_QUESTIONS_COUNT) do |num| -%>
       <% if project.extra_question(num).present? %>


### PR DESCRIPTION
This has always been kind of a pain in the butt when reviewing applications - you click on an external link (like the project link or an inline link) and then you're not in the dashboard any more and it's confusing. 

This change requires bumping redcarpet gem to support the `link_attributes` option.

NOTE: this PR does not change the behavior for the public pages - those links still open in the window you're viewing. This is mostly philosophical - when you're on the public site and you link off, I feel like that's just the nature of the web: you're choosing to go somewhere else. In the internal site, which is more app-like, I'd imagine the intention is always to stay on the site to review more projects.

First brought up in #183 again recently by Emily from AwesomePGH.