### PR TITLE
Finalist page shows if a project was a winner

### DIFF
--- a/app/assets/stylesheets/_finalists.scss
+++ b/app/assets/stylesheets/_finalists.scss
@@ -17,6 +17,10 @@ section.applications {
             color: $pink;
           }
         }
+        .winner {
+          color: $pink;
+        }
+
       }
     }
   }

--- a/app/controllers/finalists_controller.rb
+++ b/app/controllers/finalists_controller.rb
@@ -8,6 +8,7 @@ class FinalistsController < ApplicationController
   def index
     @start_date, @end_date = extract_timeframe
     @projects = Project.
+                  includes(:chapter).
                   voted_for_by_members_of(current_chapter).
                   during_timeframe(@start_date, @end_date).
                   by_vote_count

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -68,10 +68,10 @@ class Project < ActiveRecord::Base
   end
 
   def self.by_vote_count
-    select("projects.chapter_id, projects.id, projects.title, COUNT(votes.project_id) as vote_count").
+    select("projects.chapter_id, projects.id, projects.title, projects.funded_on, COUNT(votes.project_id) as vote_count").
       group("projects.id, projects.title, votes.project_id").
       joins(:users).
-      order("vote_count DESC")
+      order("vote_count DESC, projects.created_at ASC")
   end
 
   def self.winners

--- a/app/views/finalists/index.html.erb
+++ b/app/views/finalists/index.html.erb
@@ -42,7 +42,10 @@
     </tr>
     <% @projects.each do |project| %>
       <tr class="finalist" data-count="<%= project.vote_count %>" data-id="<%= project.id %>">
-        <td><%= link_to project.title, chapter_project_path(project.chapter, project) %></td>
+        <td>
+          <%= link_to project.title, chapter_project_path(project.chapter, project) %>
+          <%= link_to(raw('<i class="icon-ok-sign winner"></i>'), project_path(project), :target => "_blank", :title => t("projects.project.winner", :name => project.chapter.name)) if project.winner? %>
+        </td>
         <td><%= project.id %></td>
         <td class="vote-count"><%= project.vote_count %></td>
       </tr>


### PR DESCRIPTION
Eventually, we should have the ability to exclude winners from the finalist page (as per #232), but for now, this will at least give an indication of which finalists have been marked as winners.