### PR TITLE
Extra fields for the Atom feed

### DIFF
--- a/app/controllers/funded_projects_controller.rb
+++ b/app/controllers/funded_projects_controller.rb
@@ -1,6 +1,6 @@
 class FundedProjectsController < ApplicationController
   def index
-    @projects = Project.includes(:photos).winners.order("funded_on DESC").paginate(:page => params[:page], :per_page => 50)
+    @projects = Project.includes(:photos, :chapter).winners.order("funded_on DESC").paginate(:page => params[:page], :per_page => 50)
 
     respond_to do |format|
       format.xml

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,7 @@ module ApplicationHelper
     tag :meta, options.merge(:content => content_for?(content_tag) ? content_for(content_tag) : content)
   end
 
+  def nil_if_blank(str)
+    str.blank? ? nil : str
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,8 +35,4 @@ module ApplicationHelper
 
     tag :meta, options.merge(:content => content_for?(content_tag) ? content_for(content_tag) : content)
   end
-
-  def nil_if_blank(str)
-    str.blank? ? nil : str
-  end
 end

--- a/app/views/funded_projects/index.xml.builder
+++ b/app/views/funded_projects/index.xml.builder
@@ -5,7 +5,7 @@ atom_feed(language: I18n.locale, "xmlns:awesome" => "http://www.awesomefoundatio
   @projects.each do |project|
     feed.entry(project, :published => project.funded_on) do |entry|
       entry.title "#{project.chapter.name} – #{project.title}"
-      entry.content(nil_if_blank(project.funded_description), type: 'html')
+      entry.content(project.funded_description, type: 'html') unless project.funded_description.blank?
 
       if mime_type = MIME::Types.type_for(project.primary_image.url).first
         entry.link(href: image_url(project.primary_image.url), rel: 'enclosure', type: mime_type)
@@ -18,7 +18,7 @@ atom_feed(language: I18n.locale, "xmlns:awesome" => "http://www.awesomefoundatio
       entry.tag!("awesome:details") do |awesome|
         awesome.project do |p|
           p.name project.title
-          p.url  nil_if_blank(project.url)
+          p.url  project.url unless project.url.blank?
         end
 
         awesome.chapter do |chapter|

--- a/app/views/funded_projects/index.xml.builder
+++ b/app/views/funded_projects/index.xml.builder
@@ -5,7 +5,7 @@ atom_feed(language: I18n.locale, "xmlns:awesome" => "http://www.awesomefoundatio
   @projects.each do |project|
     feed.entry(project, :published => project.funded_on) do |entry|
       entry.title "#{project.chapter.name} – #{project.title}"
-      entry.content(project.funded_description, type: 'html')
+      entry.content(nil_if_blank(project.funded_description), type: 'html')
 
       if mime_type = MIME::Types.type_for(project.primary_image.url).first
         entry.link(href: image_url(project.primary_image.url), rel: 'enclosure', type: mime_type)
@@ -18,7 +18,7 @@ atom_feed(language: I18n.locale, "xmlns:awesome" => "http://www.awesomefoundatio
       entry.tag!("awesome:details") do |awesome|
         awesome.project do |p|
           p.name project.title
-          p.url  !project.url.blank? ? project.url : nil
+          p.url  nil_if_blank(project.url)
         end
 
         awesome.chapter do |chapter|

--- a/app/views/funded_projects/index.xml.builder
+++ b/app/views/funded_projects/index.xml.builder
@@ -1,4 +1,4 @@
-atom_feed(language: I18n.locale) do |feed|
+atom_feed(language: I18n.locale, "xmlns:awesome" => "http://www.awesomefoundation.org/") do |feed|
   feed.title t('feed.title')
   feed.updated @projects[0].updated_at unless @projects.empty?
 
@@ -15,7 +15,7 @@ atom_feed(language: I18n.locale) do |feed|
         author.name project.name
       end
 
-      entry.awesomefoundation do |awesome|
+      entry.tag!("awesome:details") do |awesome|
         awesome.project do |p|
           p.name project.title
           p.url  !project.url.blank? ? project.url : nil

--- a/app/views/funded_projects/index.xml.builder
+++ b/app/views/funded_projects/index.xml.builder
@@ -14,6 +14,19 @@ atom_feed(language: I18n.locale) do |feed|
       entry.author do |author|
         author.name project.name
       end
+
+      entry.awesomefoundation do |awesome|
+        awesome.project do |p|
+          p.name project.title
+          p.url  !project.url.blank? ? project.url : nil
+        end
+
+        awesome.chapter do |chapter|
+          chapter.country project.chapter.country
+          chapter.name    project.chapter.name
+          chapter.url     chapter_url(project.chapter)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This gives developers who want a feed of all of our funded projects a way to get most of the public data associated with each project, without us having to build a completely new API. 