### PR TITLE
Move "real image" logic (01cecd1f5bead56288) into association to enable preloading

### DIFF
--- a/app/controllers/funded_projects_controller.rb
+++ b/app/controllers/funded_projects_controller.rb
@@ -1,6 +1,6 @@
 class FundedProjectsController < ApplicationController
   def index
-    @projects = Project.includes(:photos, :chapter).winners.order("funded_on DESC").paginate(:page => params[:page], :per_page => 50)
+    @projects = Project.includes(:real_photos, :chapter).winners.order("funded_on DESC").paginate(:page => params[:page], :per_page => 50)
 
     respond_to do |format|
       format.xml

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -14,10 +14,6 @@ class Photo < ActiveRecord::Base
   cattr_accessor :fog_config
   self.fog_config = Rails.configuration.fog
 
-  def self.real_images
-    where("image_content_type LIKE 'image/%'")
-  end
-
   # Build a URL to dynamically resize application images via an external service
   # Currently using http://magickly.afeld.me/
   def url(size = nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,7 @@ class Project < ActiveRecord::Base
   has_many :votes
   has_many :users, :through => :votes
   has_many :photos, :order => "photos.sort_order asc, photos.id asc"
+  has_many :real_photos, :order => "photos.sort_order asc, photos.id asc", :conditions => proc { Photo.arel_table[:image_content_type].matches('image/%') }, :class_name => "Photo"
 
   attr_accessible :name, :title, :url, :email, :phone, :about_me, :about_project,
                   :chapter_id, :extra_question_1, :extra_question_2, :extra_question_3,
@@ -169,10 +170,10 @@ class Project < ActiveRecord::Base
   end
 
   def display_images
-    if photos.real_images.empty?
+    if real_photos.empty?
       [Photo.new]
     else
-      photos.real_images
+      real_photos
     end
   end
 


### PR DESCRIPTION
The only place the logic of whether an image was actually an image
(for web display purposes) is used is in the Project model. Move
the logic into the Project model so we can eager load #real_photos
when doing things like rendering the RSS feed.