### PR TITLE
Add ability to hide trustees from the chapter page

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -33,7 +33,8 @@ EOT
 
   attr_accessible :name, :twitter_url, :facebook_url, :blog_url, :rss_feed_url, :description,
                   :country, :extra_question_1, :extra_question_2, :extra_question_3, :slug,
-                  :email_address, :time_zone, :inactive, :locale, :submission_response_email
+                  :email_address, :time_zone, :inactive, :locale, :submission_response_email,
+                  :hide_trustees
 
   def should_generate_new_friendly_id?
     slug.blank?

--- a/app/views/chapters/_form.html.erb
+++ b/app/views/chapters/_form.html.erb
@@ -13,6 +13,7 @@
   <%= form.input :blog_url, :label => "Blog URL" %>
   <%= form.input :rss_feed_url, :label => "RSS Feed URL" %>
   <%= form.input :description %>
+  <%= form.input :hide_trustees %>
   <%= form.input :country, :priority => COUNTRY_PRIORITY %>
   <%= form.input :time_zone %>
   <%= form.input :locale, :collection => I18n.available_locales, :include_blank => false, :label => t('simple_form.labels.chapter.locale', :slug => chapter.slug) %>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -67,7 +67,7 @@
     <% end %>
   </section>
 
-  <% if @chapter.users.present? %>
+  <% if !@chapter.hide_trustees? && @chapter.users.present? %>
   <h2><%= t(".trustees.header") %></h2>
   <section class="trustees">
     <ol>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,7 @@ en:
         user_image: Set your user image at <a href="https://en.gravatar.com/site/signup/%{email}" target="_blank">gravatar.com</a> using your email address above
       chapter:
         submission_response_email: This text will be included in the confirmation emails sent to your grant applicants
+        hide_trustees: Prevent the trustee list from being displayed on the public chapter page
   activerecord:
     errors:
       models:

--- a/db/migrate/20190215211018_add_chapters_hide_trustees.rb
+++ b/db/migrate/20190215211018_add_chapters_hide_trustees.rb
@@ -1,0 +1,5 @@
+class AddChaptersHideTrustees < ActiveRecord::Migration
+  def change
+    add_column :chapters, :hide_trustees, :boolean, :null => false, :default => false
+  end
+end

--- a/spec/features/guest_views_chapter.feature
+++ b/spec/features/guest_views_chapter.feature
@@ -16,6 +16,13 @@ Feature: View chapters in the system
     When I go to the chapter page
     Then I should see the trustees
 
+  Scenario: Guest can not see list of members on chapter page if list is hidden
+    Given there is a chapter in the system
+    And the chapter has trustees hidden
+    And there are 5 trustees
+    When I go to the chapter page
+    Then I should not see the trustees
+
   Scenario: Guest can see previous winners for this chapter
     Given there is a chapter in the system
     And 5 projects have won for this chapter

--- a/spec/features/step_definitions/chapter_steps.rb
+++ b/spec/features/step_definitions/chapter_steps.rb
@@ -28,6 +28,10 @@ step 'there is a chapter in the system' do
   @current_chapter = FactoryGirl.create(:chapter, :rss_feed_url => Rails.root.join('spec', 'support', 'feed.xml').to_s)
 end
 
+step 'the chapter has trustees hidden' do
+  @current_chapter.update_attribute(:hide_trustees, true)
+end
+
 step 'there is an inactive chapter in the system' do
   @current_chapter = FactoryGirl.create(:inactive_chapter)
 end

--- a/spec/features/step_definitions/guest_views_chapter.rb
+++ b/spec/features/step_definitions/guest_views_chapter.rb
@@ -13,3 +13,7 @@ step 'I should see the trustees' do
     page.should have_selector(".trustee-details h3", :text => "#{trustee.first_name} #{trustee.last_name}")
   end
 end
+
+step 'I should not see the trustees' do
+  expect(page).to_not have_selector('.trustees')
+end


### PR DESCRIPTION
A request from a local chapter: "while we know it's not for everyone—perhaps not even us after this trial year—really like the idea of this money being purely from Awesome. Just a group of neighbors. Not these ten people linked to their info."

This is a setting and defaults to false (i.e. the default behavior is to show the trustee section)