### PR TITLE
Bump thin to 1.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'pg', '~> 0.13.2'
 gem 'texticle', '~> 2.0', :require => 'texticle/rails'
 gem 'jquery-rails', '~> 2.1.0'
 gem 'clearance', '~> 0.16.2'
-gem 'thin'
 gem 'sass'
 gem 'high_voltage'
 gem 'paperclip', '~> 3.0.3'
@@ -43,6 +42,7 @@ gem 'rollbar'
 
 group :development do
   gem "letter_opener"
+  gem 'thin'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       json
     country_select (0.0.2)
     daemon_controller (1.2.0)
-    daemons (1.1.8)
+    daemons (1.3.1)
     database_cleaner (0.7.2)
     debugger-linecache (1.2.0)
     diesel (0.1.5)
@@ -84,7 +84,7 @@ GEM
       launchy (~> 2.1)
       mail (~> 2.2)
     erubis (2.7.0)
-    eventmachine (0.12.10)
+    eventmachine (1.2.7)
     evergreen (1.1.3)
       capybara (>= 2.1.0)
       coffee-script
@@ -350,10 +350,10 @@ GEM
       celluloid (~> 0.15.2)
     texticle (2.0.3)
       activerecord (~> 3.0)
-    thin (1.3.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (0.19.4)
     tilt (1.4.1)
     timecop (0.3.5)
@@ -433,5 +433,8 @@ DEPENDENCIES
   uglifier
   will_paginate (~> 3.0.3)
 
+RUBY VERSION
+   ruby 2.1.7p400
+
 BUNDLED WITH
-   1.15.1
+   1.17.3


### PR DESCRIPTION
Was having trouble installing all the gems with a modern openssl
Bumping thin (and therefore eventmachine) seems to fix this