### PR TITLE
For projects and finalists, when a start date is chosen, set the default end date to be the same

### DIFF
--- a/app/views/finalists/index.html.erb
+++ b/app/views/finalists/index.html.erb
@@ -56,7 +56,7 @@
 <% content_for :javascript do %>
   <% javascript_tag do %>
     $(window).load(function(){
-      $('#filter_start').datepicker({dateFormat: 'yy-mm-dd', onClose: function(){ $('#filter_start').blur() }});
+      $('#filter_start').datepicker({dateFormat: 'yy-mm-dd', onClose: function(dateText){ $('#filter_start').blur(); $('#filter_end').datepicker('option', 'defaultDate', dateText); $('#filter_end').blur() }});
       $('#filter_end').datepicker({dateFormat: 'yy-mm-dd', onClose: function(){ $('#filter_end').blur() }});
     });
   <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -58,7 +58,7 @@
 <% content_for :javascript do %>
   <% javascript_tag do %>
     $(window).load(function(){
-      $('#filter_start').datepicker({dateFormat: 'yy-mm-dd', onClose: function(){ $('#filter_start').blur() }});
+      $('#filter_start').datepicker({dateFormat: 'yy-mm-dd', onClose: function(dateText){ $('#filter_start').blur(); $('#filter_end').datepicker('option', 'defaultDate', dateText); $('#filter_end').blur() }});
       $('#filter_end').datepicker({dateFormat: 'yy-mm-dd', onClose: function(){ $('#filter_end').blur() }});
     });
   <% end %>


### PR DESCRIPTION
* Selecting a start date will change the end date calendar picker to the same month
* Should make it a little more convenient to choose a date range (which is normally the first through the last of the month)
* If the end date is already selected, do not change it
* Does not actually set the end date, so if you just choose a start date, end date remains blank

Doesn't quite address #251 but it should make the process of choosing a date range a little smoother.