### PR TITLE
Project titles in the image carousel on the project page should wrap, not overflow

### DIFF
--- a/app/assets/stylesheets/_chapters-show.scss
+++ b/app/assets/stylesheets/_chapters-show.scss
@@ -243,6 +243,7 @@ body.chapters-show {
           position: absolute;
           bottom: 0px;
           width: 100%;
+          white-space: normal;
 
           h2 {
             color: rgb(255,255,255);


### PR DESCRIPTION
This bug was introduced in 953c39f0090612666d32059ba4912e5fff2f70ca

Closes #349 