### PR TITLE
auto-orient images when resizing/cropping them

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -70,7 +70,7 @@ class Photo < ApplicationRecord
     # We unescape before re-escaping because the URL that comes from Paperclip is already
     # escaped, so without unescaping, we'd be double-escaping the URL, which causes problems
     # especially with UTF-8 encoded filenames.
-    [ "src", URI.unescape(image_with_host(image_url)), "output", "jpg", "thumb", crop ].collect { |part| CGI.escape(part) }.join("/")
+    [ "src", URI.unescape(image_with_host(image_url)), "output", "jpg", "convert", "-auto-orient", "thumb", crop ].collect { |part| CGI.escape(part) }.join("/")
   end
 
   def image_with_host(image_url)


### PR DESCRIPTION
Images that are made with mobile phones have orientation built-in to the image. On desktop browsers, the images will display as-cropped (horizontally) but on mobile they will be rotated back to portrait since the image orientation is still in the image. We pass in the -auto-orient flag to magickly (and thus to ImageMagick) to respect the image-defined orientation and rotate before cropping.