### PR TITLE
Subdomain constraint uses SUBDOMAIN environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ AWS_SECRET_ACCESS_KEY=YYY
 AWS_BUCKET=your-bucket-name
 ```
 
+Subdomains
+----------
+
+The site supports chapter subdomain redirects. When a wildcard DNS record is set up to point at the app, all traffic to subdomains other than `www` and the subdomain that is contained in the `SUBDOMAIN` environment variable will be redirected to the chapter page with that subdomain set as the chapter slug.
+
+For example, `nyc.awesomefoundation.org` redirects to `www.awesomefoundation.org/en/chapters/nyc`
+
+In order to prevent that redirect for other installations (such as staging environments), or for testing with a service like [ngrok](https://ngrok.io), set the `SUBDOMAIN` environment variable to the site's subdomain.
+
+```shell
+SUBDOMAIN=staging
+```
+
+
 Secret Token
 ------------
 

--- a/app/extras/subdomain_constraint.rb
+++ b/app/extras/subdomain_constraint.rb
@@ -1,7 +1,7 @@
 class SubdomainConstraint
   def self.matches?(request)
     case request.subdomains.first
-    when 'www', '', nil, 'staging', 'preview'
+    when 'www', '', nil, ENV['SUBDOMAIN']
       false
     else
       true

--- a/spec/controllers/subdomains_controller_spec.rb
+++ b/spec/controllers/subdomains_controller_spec.rb
@@ -10,6 +10,14 @@ describe SubdomainsController do
     it { is_expected.to route(:get, "http://www.test.host").to(:controller => "home", :action => "index") }
   end
 
+  context "with ENV subdomain" do
+    before do
+      ENV["SUBDOMAIN"] = "env"
+    end
+
+    it { is_expected.to route(:get, "http://env.test.host").to(:controller => "home", :action => "index") }
+  end
+
   context 'with chapter subdomain' do
     it { is_expected.to route(:get, "http://subdomain.test.host").to(:controller => "subdomains", :action => "chapter") }
     it { is_expected.to route(:get, "http://subdomain.test.host/apply").to(:controller => "subdomains", :action => "apply") }


### PR DESCRIPTION
Rather than hard code the canonical subdomain, read it from an environment variable instead (to support staging, preview, etc)