### PR TITLE
Add Chapter#display_name to identify "inactive" chapters

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -87,7 +87,7 @@ EOT
     end
   end
 
-  def name
+  def display_name
     if inactive?
       "#{self[:name]} (#{I18n.t('word.inactive')})"
     else

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -1,6 +1,6 @@
 <article href="#" class="chapter">
   <div class="inner-wrapper">
-    <h2 class="name"><%= link_to chapter.name, chapter_path(chapter) %></h2>
+    <h2 class="name"><%= link_to chapter.display_name, chapter_path(chapter) %></h2>
     <div class="external-links">
       <%= link_to "", chapter.twitter_url, :class => :twitter_url, :title => Chapter.human_attribute_name(:twitter_url) if chapter.twitter_url.present? %>
       <%= link_to "", chapter.facebook_url, :class => :facebook_url, :title => Chapter.human_attribute_name(:facebook_url) if chapter.facebook_url.present? %>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -1,9 +1,9 @@
-<%= provide(:page_title, @chapter.name) %>
+<%= provide(:page_title, @chapter.display_name) %>
 
 <header>
   <div class="title">
     <h1>
-      <%= @chapter.name %>
+      <%= @chapter.display_name %>
     </h1>
 
     <% if can_manage_chapter?(@chapter) %>
@@ -62,7 +62,7 @@
 
     <% if @chapter.rss_feed_url.present? %>
     <article class="rss-feed half" data-feed-url="<%= @chapter.rss_feed_url %>">
-      <h2><%= t(".trustees.news", :name => @chapter.name) %></h2>
+      <h2><%= t(".trustees.news", :name => @chapter.display_name) %></h2>
       <section class="rss" id="rss-feeds"></section>
     </article>
     <% end %>

--- a/app/views/finalists/index.html.erb
+++ b/app/views/finalists/index.html.erb
@@ -5,16 +5,16 @@
 </section>
 
 <section class="applications">
-  <h1><%= t ".title", :name => @chapter.name %></h1>
+  <h1><%= t ".title", :name => @chapter.display_name %></h1>
   <section class="application-filters">
     <nav>
       <%= link_to '#', :class => 'chapter-selection' do %>
-        <span><%= @chapter.name %></span>
+        <span><%= @chapter.display_name %></span>
         <span class="arrow"></span>
       <% end %>
       <ol class="chapter-selector">
         <% selectable_chapters_for(current_user)[1..-1].each do |chapter| %>
-          <li><%= link_to chapter.name, chapter_finalists_path(chapter) %></li>
+          <li><%= link_to chapter.display_name, chapter_finalists_path(chapter) %></li>
         <% end %>
       </ol>
     </nav>
@@ -44,7 +44,7 @@
       <tr class="finalist" data-count="<%= project.vote_count %>" data-id="<%= project.id %>">
         <td>
           <%= link_to project.title, chapter_project_path(project.chapter, project) %>
-          <%= link_to(raw('<i class="icon-ok-sign winner"></i>'), project_path(project), :target => "_blank", :title => t("projects.project.winner", :name => project.chapter.name)) if project.winner? %>
+          <%= link_to(raw('<i class="icon-ok-sign winner"></i>'), project_path(project), :target => "_blank", :title => t("projects.project.winner", :name => project.chapter.display_name)) if project.winner? %>
         </td>
         <td><%= project.id %></td>
         <td class="vote-count"><%= project.vote_count %></td>

--- a/app/views/funded_projects/index.xml.builder
+++ b/app/views/funded_projects/index.xml.builder
@@ -4,7 +4,7 @@ atom_feed(language: I18n.locale, "xmlns:awesome" => "http://www.awesomefoundatio
 
   @projects.each do |project|
     feed.entry(project, :published => project.funded_on) do |entry|
-      entry.title "#{project.chapter.name} – #{project.title}"
+      entry.title "#{project.chapter.display_name} – #{project.title}"
       entry.content(project.funded_description, type: 'html') unless project.funded_description.blank?
 
       if mime_type = MIME::Types.type_for(project.primary_image.url).first
@@ -23,7 +23,7 @@ atom_feed(language: I18n.locale, "xmlns:awesome" => "http://www.awesomefoundatio
 
         awesome.chapter do |chapter|
           chapter.country project.chapter.country
-          chapter.name    project.chapter.name
+          chapter.name    project.chapter.display_name
           chapter.url     chapter_url(project.chapter)
         end
       end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,7 +12,7 @@
           <p><%= t ".by", :name => project.name %></p>
         </div>
         <div class="funding-chapter">
-          <h3><%= image_tag("location_pin_small.png") %> <%= project.chapter.name %></h3>
+          <h3><%= image_tag("location_pin_small.png") %> <%= project.chapter.display_name %></h3>
         </div>
         <%= image_tag(project.primary_image.url(:index)) %>
       <% end %>
@@ -37,7 +37,7 @@
           <p><%= t ".by", :name => project.name %></p>
         </div>
         <div class="funding-chapter">
-          <h3><%= image_tag("location_pin_small.png") %> <%= project.chapter.name %></h3>
+          <h3><%= image_tag("location_pin_small.png") %> <%= project.chapter.display_name %></h3>
         </div>
         <%= image_tag(project.primary_image.url(:index)) %>
       <% end %>
@@ -86,7 +86,7 @@
 <section class="awesome-chapters">
   <% @chapters.each do |chapter| %>
       <%= link_to chapter, :class => "image-wrapper" do %>
-        <%= chapter.name %>
+        <%= chapter.display_name %>
       <% end %>
   <% end %>
 </section>

--- a/app/views/invitation_mailer/invite_trustee.text.erb
+++ b/app/views/invitation_mailer/invite_trustee.text.erb
@@ -1,7 +1,7 @@
 Hi <%= @invitation.first_name %> <%= @invitation.last_name %>!
 
 You have been invited to join AwesomeFoundation.org as a trustee of the
-<%= @invitation.chapter.name %> chapter! Yay!
+<%= @invitation.chapter.display_name %> chapter! Yay!
 
 <%= new_invitation_acceptance_url(@invitation, :locale => I18n.locale) %>
 

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -5,7 +5,7 @@
       <%= form.input :chapter_id, :as => :select, :collection => invitable_chapters, :group_method => :name, :label => "Select a chapter", :prompt => "- Select -" %>
     <% else %>
       <p>Trustee will be invited to:
-        <span><%= primary_invitable_chapter.name %></span>
+        <span><%= primary_invitable_chapter.display_name %></span>
       </p>
       <%= form.input :chapter_id, :as => :hidden, :input_html => { :value => primary_invitable_chapter.id } %>
     <% end %>

--- a/app/views/project_mailer/new_application.text.erb
+++ b/app/views/project_mailer/new_application.text.erb
@@ -13,7 +13,7 @@ Your email: <%= @project.email %>
 Your phone number: <%= @project.phone %>
 Project title: <%= @project.title %>
 Project website: <%= @project.url %>
-Chapter: <%= @project.chapter.name %>
+Chapter: <%= @project.chapter.display_name %>
 
 About me:
 <%= @project.about_me %>

--- a/app/views/projects/_project_details.html.erb
+++ b/app/views/projects/_project_details.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <section class="meta-data">
-    <%= project.created_at %> (<%= project.chapter.name %>)
+    <%= project.created_at %> (<%= project.chapter.display_name %>)
 
     <section class="project-actions">
       <ul class="icons-ul">

--- a/app/views/projects/_project_hidden.html.erb
+++ b/app/views/projects/_project_hidden.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <section class="meta-data">
-    <%= project.created_at %> (<%= project.chapter.name %>)
+    <%= project.created_at %> (<%= project.chapter.display_name %>)
 
     <% if project.winner? %>
       · <%= link_to I18n.t(".view-public-page", scope: "projects.project"), project_path(project), :target => "blank" %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -5,16 +5,16 @@
 </section>
 
 <section class="applications">
-  <h1><%= t ".title", :name => @chapter.name, :count => @projects.count %></h1>
+  <h1><%= t ".title", :name => @chapter.display_name, :count => @projects.count %></h1>
   <section class="application-filters">
     <nav>
       <%= link_to '#', :class => 'chapter-selection' do %>
-        <span><%= @chapter.name %></span>
+        <span><%= @chapter.display_name %></span>
         <span class="arrow"></span>
       <% end %>
       <ol class="chapter-selector">
         <% selectable_chapters_for(current_user).each do |chapter| %>
-          <li><%= link_to chapter.name, chapter_projects_path(chapter) %></li>
+          <li><%= link_to chapter.display_name, chapter_projects_path(chapter) %></li>
         <% end %>
       </ol>
     </nav>

--- a/app/views/projects/public_show.html.erb
+++ b/app/views/projects/public_show.html.erb
@@ -32,7 +32,7 @@
 
 <section class="project-details">
   <section class="meta-data">
-    <p><%= t(".byline-html", :chapter_name => link_to(@project.chapter.name, chapter_path(@project.chapter)), :submitter_name => @project.name) %></p>
+    <p><%= t(".byline-html", :chapter_name => link_to(@project.chapter.display_name, chapter_path(@project.chapter)), :submitter_name => @project.name) %></p>
     <div class="addthis_toolbox addthis_default_style ">
       <a class="addthis_button_twitter"></a>
       <a class="addthis_button_facebook"></a>
@@ -73,11 +73,11 @@
     <article class="project-state">
       <% if @project.winner? %>
         <div class="state funded">
-          <p><%= t(".funder-html", :name => @project.chapter.name) %> <span class="funded-on">(<%= l @project.funded_on, :format => :funding %>)</span></p>
+          <p><%= t(".funder-html", :name => @project.chapter.display_name) %> <span class="funded-on">(<%= l @project.funded_on, :format => :funding %>)</span></p>
         </div>
       <% else %>
         <div class="state applied">
-          <p><%= t(".submitted-to-html", :name => @project.chapter.name) %></p>
+          <p><%= t(".submitted-to-html", :name => @project.chapter.display_name) %></p>
         </div>
       <% end %>
     </article>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -7,10 +7,10 @@
 </section>
 
 <section class="applications">
-  <h1><%= t "projects.index.title", :name => @project.chapter.name, :count => 1 %></h1>
+  <h1><%= t "projects.index.title", :name => @project.chapter.display_name, :count => 1 %></h1>
 
   <p>
-    <%= raw t ".back-to", :name => @project.chapter.name, :url => chapter_projects_path(@project.chapter) %>
+    <%= raw t ".back-to", :name => @project.chapter.display_name, :url => chapter_projects_path(@project.chapter) %>
   </p>
 
   <%= render @project, full_view: true %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -29,7 +29,7 @@
           <article class="country">
             <h3><%= chapter.country %></h3>
         <% end %>
-        <p><%= link_to chapter.name, chapter %></p>
+        <p><%= link_to chapter.display_name, chapter %></p>
       <% end %>
       </article>
     </section>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <li class="section-title">
-    <h3><%= chapter.name %></h3>
+    <h3><%= chapter.display_name %></h3>
   </li>
   <li><%= link_to t(".projects"), chapter_projects_path(chapter) %></li>
   <% unless chapter.any_chapter? %>

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -149,7 +149,7 @@ describe Chapter do
     it 'indicates that an inactive chapter is Inactive' do
       chapter = FactoryGirl.build(:inactive_chapter, :name => 'Inactive Chapter')
 
-      expect(chapter.name).to eq('Inactive Chapter (Inactive)')
+      expect(chapter.display_name).to eq('Inactive Chapter (Inactive)')
     end
   end
 end


### PR DESCRIPTION
We originally overrode Chapter#name but this caused the unintended side effect of changing the name of the chapter in the chapter edit form if the chapter being edited was inactive. It is now more explicit that we are showing a possibly-modified chapter name.

Closes #365 