### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ cache: bundler
 bundler_args: --without production
 rvm:
   - 2.5.5
+services:
+  # https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
+  - xvfb
 before_install:
-  # Get the headless webkit running on Travis
-  # http://stackoverflow.com/questions/11448806/headless-gem-webkit-server-cannot-connect-to-x-server
-  - "echo 'gem: --no-document' > ~/.gemrc"
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   # To keep using bundler < 2.0
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ before_script:
   - RAILS_ENV=test bundle exec rake db:create
   - RAILS_ENV=test bundle exec rake db:migrate --trace
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
   chrome: stable


### PR DESCRIPTION
Travis seems to have a new way of launching xvfb:

https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui

Also bump the postgresql version while we're at it to match the version we're running on Heroku.