### PR TITLE
Change Photo db fields from string to text

### DIFF
--- a/db/migrate/20190430194718_fix_photos_field_lengths.rb
+++ b/db/migrate/20190430194718_fix_photos_field_lengths.rb
@@ -1,0 +1,11 @@
+class FixPhotosFieldLengths < ActiveRecord::Migration[5.2]
+  def up
+    change_column :photos, :image_file_name, :text
+    change_column :photos, :direct_upload_url, :text
+  end
+
+  def down
+    change_column :photos, :image_file_name, :string
+    change_column :photos, :direct_upload_url, :string
+  end
+end


### PR DESCRIPTION
User-uploaded images have varying lengths, and in the case of storing the direct_upload_url sometimes that URL can exceed the 255 character limit default for a string. Since Postgres will treat strings and varchars the same internally, let's just remove the length limit completely.

Closes #226