### PR TITLE
Use the SUBDOMAIN environment variable to set the default ActionMailer host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: 'www.awesomefoundation.org' }
+  config.action_mailer.default_url_options = { host: "#{ENV['SUBDOMAIN'] || 'www'}.awesomefoundation.org" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Ensure that password reset emails include the correct hostname.