### PR TITLE
Bump Nokogiri gem to 1.10.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'formtastic'
 gem 'flutie'
 gem 'bourbon', '~> 4.0.2'
 gem 'simple_form', '~> 4.1'
-gem 'nokogiri', '~> 1.10.1'
+gem 'nokogiri', '~> 1.10.4'
 gem "will_paginate", "~> 3.1.7"
 gem "friendly_id", "~> 5.2.4"
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     multi_json (1.13.1)
     newrelic_rpm (3.18.1.330)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     paperclip (4.1.1)
       activemodel (>= 3.0.0)
@@ -540,7 +540,7 @@ DEPENDENCIES
   listen
   magnific-popup-rails
   newrelic_rpm (~> 3.18.1)
-  nokogiri (~> 1.10.1)
+  nokogiri (~> 1.10.4)
   paperclip (~> 4.1.1)
   passenger
   pg (~> 0.20.0)


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-5477