### PR TITLE
Fix uploads

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -9,6 +9,8 @@ class Photo < ApplicationRecord
     gallery:         "2000x>",
   }
 
+  MAX_FILE_SIZE = 20.megabytes
+
   belongs_to :project, optional: true
   has_attached_file :image,
                     default_url: "no-image-:style.png"

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -39,10 +39,10 @@ class Photo < ApplicationRecord
     if persisted? && direct_upload_url.present?
       set_attributes_from_direct_upload
 
-      if uploaded_file = bucket.files.get(direct_upload_path)
+      if uploaded_file = bucket.files.head(direct_upload_path)
         uploaded_file.copy(fog_config.bucket, image.path)
 
-        destination_file = bucket.files.get(image.path)
+        destination_file = bucket.files.head(image.path)
         destination_file.public = true
         destination_file.save
 
@@ -86,7 +86,7 @@ class Photo < ApplicationRecord
   end
 
   def set_attributes_from_direct_upload
-    file = bucket.files.get(direct_upload_path)
+    file = bucket.files.head(direct_upload_path)
 
     self.image_file_name = File.basename(direct_upload_path).gsub(image.options[:restricted_characters], "_")
     self.image_content_type = file.content_type

--- a/app/views/projects/_image_form.html.erb
+++ b/app/views/projects/_image_form.html.erb
@@ -2,7 +2,7 @@
     <label class="file optional"><%= t "simple_form.labels.project.new_photos-html" %></label>
     <div class="multi-input first noremove" data-num-files="<%= Project::MAX_PHOTOS %>">
       <% if upload_mechanism == :s3 %>
-        <%= form.s3_file_field :new_photos, :class => "s3_upload_field", :name => "project[new_photo_direct_upload_urls][]", :accept => "image/*"  %>
+        <%= form.s3_file_field :new_photos, :class => "s3_upload_field", :name => "project[new_photo_direct_upload_urls][]", :accept => "image/*", :max_file_size => Photo::MAX_FILE_SIZE %>
       <% else %>
         <input class="file optional multi new_photo" id="project_new_photos" name="project[new_photos][]" type="file" value="" accept="image/*">
       <% end %>


### PR DESCRIPTION
This PR does two things:

1. When copying uploaded files from the uploads/ folder on s3 to their final destination, we used to actually download the entire file to fetch the metadata, which was just totally wrong. Switch the fog calls to just call `head` instead
2. Limit the actual file size to 20mb. This should be plenty and it'll keep us from dealing with people uploading 500mb videos.