### PR TITLE
BUGFIX: fix project text search

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -32,7 +32,7 @@ class ProjectsController < ApplicationController
     respond_to do |format|
       format.html do
         @projects = project_filter.page(params[:page]).result.includes(:users, :photos, :real_photos)
-        @comments = Comment.where(project_id: @projects).includes(:user, :project).viewable_by(user: current_user, chapter: @chapter).by_date
+        @comments = Comment.where(project_id: @projects.collect(&:id)).includes(:user, :project).viewable_by(user: current_user, chapter: @chapter).by_date
 
         current_user.mark_last_viewed_chapter(params[:chapter_id])
       end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -23,6 +23,26 @@ describe ProjectsController do
     it { is_expected.to redirect_to(root_path) }
   end
 
+  context 'viewing the index with a search term' do
+    render_views
+
+    let(:user) { FactoryGirl.create(:user) }
+    let(:project) { FactoryGirl.create(:project, title: "Find Me") }
+    let!(:missing_project) { FactoryGirl.create(:project, chapter: project.chapter) }
+
+    before do
+      sign_in_as user
+    end
+
+    it "returns the matching project only" do
+      get :index, params: { chapter_id: project.chapter, q: "Find Me" }
+
+      expect(response.status).to eq(200)
+      expect(response.body).to match("Find Me")
+      expect(response.body).to match("1 Project")
+    end
+  end
+
   context 'attempting to delete a project as a trustee who is not the dean or an admin' do
     let(:user) { FactoryGirl.create(:user) }
     let(:project) { FactoryGirl.create(:project) }


### PR DESCRIPTION
This broke when we added commenting since the comment query was expecting ids, but textacular was giving us back a huge pile of other select values.