### PR TITLE
BUGFIX: Make styling for "back to chapter" link on project page more specific

### DIFF
--- a/app/assets/stylesheets/_projects-index.scss
+++ b/app/assets/stylesheets/_projects-index.scss
@@ -124,7 +124,8 @@ body.projects-index {
   float: left;
   max-width: grid-width(9);
   
-  p:nth-child(2) {
+  /* Ensure 'Back to Chapter' link on admin view of project page is the correct font size */
+  > p:nth-child(2) {
     font-size: 0.8em;
   }
 


### PR DESCRIPTION
This style only applies to that link, so make it more specific since without the specificity it was also affecting multi-paragraph comments (which actually aren't supported yet, but that's another issue).