### PR TITLE
Remove unnecessary chromedriver from github actions setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,12 +27,6 @@ jobs:
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems
 
-    - uses: nanasess/setup-chromedriver@master
-    - run: |
-        export DISPLAY=:99
-        chromedriver --url-base=/wd/hub &
-        sudo Xvfb -ac :99 -screen 0 1270x1024x24 > /dev/null 2>&1 &
-
     - name: Build and test
       env:
         POSTGRES_HOST: localhost


### PR DESCRIPTION
Chromedriver is inclued by default in the ubuntu-18.04 image

https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md#browsers-and-drivers