### PR TITLE
Admins can update winners in any chapter, not just their own

### DIFF
--- a/app/controllers/winners_controller.rb
+++ b/app/controllers/winners_controller.rb
@@ -60,7 +60,7 @@ class WinnersController < ApplicationController
   end
 
   def must_be_able_to_mark_winner
-    unless current_user.can_mark_winner?(current_project) && current_user.chapters.include?(winning_chapter)
+    unless current_user.admin? || (current_user.can_mark_winner?(current_project) && current_user.chapters.include?(winning_chapter))
       flash[:notice] = t("flash.permissions.cannot-mark-winner")
       redirect_location = chapter_projects_path(current_project.chapter)
 

--- a/app/controllers/winners_controller.rb
+++ b/app/controllers/winners_controller.rb
@@ -1,4 +1,5 @@
 class WinnersController < ApplicationController
+  before_action :must_be_logged_in
   before_action :must_be_able_to_mark_winner, only: [:create, :update, :destroy]
 
   def create

--- a/spec/controllers/winners_controller_spec.rb
+++ b/spec/controllers/winners_controller_spec.rb
@@ -1,32 +1,61 @@
 require 'spec_helper'
 
 describe WinnersController do
-  let(:user) { FactoryGirl.create(:user_with_dean_role) }
   let(:other_chapter) { FactoryGirl.create(:chapter) }
 
   before do
     sign_in_as user
   end
 
-  context "a project is in a real chapter" do
-    let(:project) { FactoryGirl.create(:project) }
+  context "a dean is logged in" do
+    let(:user) { FactoryGirl.create(:user_with_dean_role) }
 
-    it "cannot set the winner for another chapter by a dean" do
-      post :create, params: { project_id: project.id, chapter_id: other_chapter.id }
+    context "a project is in a real chapter" do
+      let(:project) { FactoryGirl.create(:project) }
 
-      expect(project.reload.winner?).to be false
-      expect(flash[:notice]).not_to be_blank
+      it "cannot set the winner for another chapter" do
+        post :create, params: { project_id: project.id, chapter_id: other_chapter.id }
+
+        expect(project.reload.winner?).to be false
+        expect(flash[:notice]).not_to be_blank
+      end
+    end
+
+    context "a project is in the Any chapter" do
+      let(:project) { FactoryGirl.create(:project, chapter: Chapter.find_by_name('Any')) }
+
+      it "cannot set the winner for another chapter" do
+        post :create, params: { project_id: project.id, chapter_id: other_chapter.id }
+
+        expect(project.reload.winner?).to be false
+        expect(flash[:notice]).not_to be_blank
+      end
     end
   end
 
-  context "a project is in the Any chapter" do
-    let(:project) { FactoryGirl.create(:project, :chapter => Chapter.find_by_name('Any')) }
+  context "an admin is logged in" do
+    let(:user) { FactoryGirl.create(:admin) }
 
-    it "cannot set the winner for another chapter by a dean" do
-      post :create, params: { project_id: project.id, chapter_id: other_chapter.id }
+    context "a project is in a real chapter" do
+      let(:project) { FactoryGirl.create(:project) }
 
-      expect(project.reload.winner?).to be false
-      expect(flash[:notice]).not_to be_blank
+      it "can set the winner for another chapter" do
+        post :create, params: { project_id: project.id, chapter_id: other_chapter.id }
+
+        expect(project.reload.winner?).to be true
+        expect(flash[:notice]).to be_blank
+      end
+    end
+
+    context "a project is in the Any chapter" do
+      let(:project) { FactoryGirl.create(:project, chapter: Chapter.find_by_name('Any')) }
+
+      it "can set the winner for another chapter" do
+        post :create, params: { project_id: project.id, chapter_id: other_chapter.id }
+
+        expect(project.reload.winner?).to be true
+        expect(flash[:notice]).to be_blank
+      end
     end
   end
 end

--- a/spec/controllers/winners_controller_spec.rb
+++ b/spec/controllers/winners_controller_spec.rb
@@ -4,7 +4,18 @@ describe WinnersController do
   let(:other_chapter) { FactoryGirl.create(:chapter) }
 
   before do
-    sign_in_as user
+    sign_in_as(user) if defined?(user)
+  end
+
+  context "user is not logged in" do
+    let(:project) { FactoryGirl.create(:project) }
+
+    it "redirects when trying to view the edit page" do
+      get :edit, params: { chapter_id: project.chapter_id, project_id: project.id }
+
+      expect(response.status).to eq(302)
+      expect(flash[:notice]).to eq(I18n.t("flash.permissions.must-be-logged-in"))
+    end
   end
 
   context "a dean is logged in" do


### PR DESCRIPTION
This functionality was mistakenly removed in b92f8bbc533e