### PR TITLE
Finalists page displays chapter name for projects from other chapters

### DIFF
--- a/app/views/finalists/index.html.erb
+++ b/app/views/finalists/index.html.erb
@@ -45,6 +45,9 @@
         <td>
           <%= link_to project.title, chapter_project_path(project.chapter, project) %>
           <%= link_to(raw('<i class="icon-ok-sign winner"></i>'), project_path(project), :target => "_blank", :title => t("projects.project.winner", :name => project.chapter.display_name)) if project.winner? %>
+          <% if project.chapter != @chapter %>
+            - <em><%= project.chapter.display_name %></em>
+          <% end %>
         </td>
         <td><%= project.id %></td>
         <td class="vote-count"><%= project.vote_count %></td>

--- a/spec/views/finalists_views_spec.rb
+++ b/spec/views/finalists_views_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'finalists/index' do
+  let!(:user) { FactoryGirl.create(:user_with_dean_role) }
+  let!(:project1) { FactoryGirl.create(:project) }
+  let!(:project2) { FactoryGirl.create(:project) }
+
+  describe 'when a project from another chapter has votes from our trustees' do
+    it 'displays the name of the other chapter next to that project title' do
+      Vote.create(user: user, project: project1)
+      Vote.create(user: user, project: project2)
+
+      assign(:chapter, project1.chapter)
+      assign(:projects, Project.by_vote_count)
+      view.stubs(:current_user).returns(user)
+
+      render
+      expect(rendered).not_to have_css("tr[data-id=\"#{project1.id}\"] td em", text: project1.chapter.display_name)
+      expect(rendered).to have_css("tr[data-id=\"#{project2.id}\"] td em", text: project2.chapter.display_name)
+    end
+  end
+end


### PR DESCRIPTION
A project from one chapter might show up in the Finalists list for another chapter if someone from that chapter voted for it in a particular timeframe (either in cases where a user is in multiple chapters or if someone was just browsing someone else's projects). This will display the name of the chapter for those projects so we know that they're from another project during review.