### PR TITLE
Add Vote#chapter so votes stick with their chapter even if users move around

### DIFF
--- a/app/assets/javascripts/projects.js.coffee
+++ b/app/assets/javascripts/projects.js.coffee
@@ -5,13 +5,15 @@ shortlist_before_send = (event, data, xhr) ->
 
 shortlist_success = (event, data, status, xhr) ->
   project_container = $('article[data-id="'+data.project_id+'"]')
+  vote_button = project_container.find('a.short-list[data-chapter="'+data.chapter_id+'"]')
   $(event.currentTarget).blur()
   if data.shortlisted
     project_container.addClass('shortlisted')
-    project_container.find('a.short-list').attr('data-method', 'delete')
+    vote_button.attr('data-method', 'delete')
   else
     project_container.removeClass('shortlisted')
-    project_container.find('a.short-list').attr('data-method', 'post')
+    vote_button.attr('data-method', 'post')
+    project_container.find('a.short-list[data-chapter=""]').remove()
 
 shortlist_failure = (xhr, status, error) ->
   alert(error.message)

--- a/app/assets/stylesheets/_projects-index.scss
+++ b/app/assets/stylesheets/_projects-index.scss
@@ -253,7 +253,7 @@ body.projects-index {
       float: right;
       padding: 0px 10px 10px 10px;
 
-      div.short-list-toggle, div.funded-toggle {
+      div.short-list-toggle, div.funded-toggle, div.toggle {
         float: left;
         margin-right: 10px;
         margin-top: 20px;
@@ -573,6 +573,9 @@ body.projects-index {
     div.title {
       a.short-list {
         @include button($pink);
+      }
+      a.short-list[data-method="post"] {
+        display: none;
       }
     }
   }

--- a/app/controllers/finalists_controller.rb
+++ b/app/controllers/finalists_controller.rb
@@ -9,9 +9,13 @@ class FinalistsController < ApplicationController
     @start_date, @end_date = extract_timeframe
     @projects = Project.
                   includes(:chapter).
-                  voted_for_by_members_of(current_chapter).
+                  with_votes_for_chapter(current_chapter).
                   during_timeframe(@start_date, @end_date).
                   by_vote_count
+
+    unless params[:past_trustees].present?
+      @projects = @projects.with_votes_by_members_of_chapter(current_chapter)
+    end
   end
 
   private

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -4,9 +4,9 @@ class VotesController < ApplicationController
   def create
     @project = Project.find(params[:project_id])
     @user = current_user
-    @vote = Vote.new(:user => @user, :project => @project)
+    @vote = Vote.new(user: @user, project: @project, chapter_id: params[:chapter_id])
     if @vote.save
-      render :json => {:shortlisted => true, :project_id => @project.id}
+      render json: {shortlisted: true, project_id: @project.id, chapter_id: params[:chapter_id]}
     else
       render :json => {:message => t("flash.votes.already-voted")}, :status => 400
     end
@@ -15,12 +15,11 @@ class VotesController < ApplicationController
   def destroy
     @project = Project.find(params[:project_id])
     @user = current_user
-    if @vote = Vote.find_by_project_id_and_user_id(@project, @user)
+    if @vote = @user.votes.find_by(project: @project)
       @vote.destroy
-      render :json => {:shortedlisted => false, :project_id => @project.id}
+      render json: {shortlisted: false, project_id: @project.id, chapter_id: params[:chapter_id]}
     else
       render :json => {:message => t("flash.votes.already-deleted")}, :status => 400
     end
   end
-
 end

--- a/app/extras/vote_migrator.rb
+++ b/app/extras/vote_migrator.rb
@@ -1,0 +1,109 @@
+class VoteMigrator
+  def migrate!(explicit_mappings: {})
+    migrate_voter_in_chapter!
+    migrate_any_chapter_votes!
+    migrate_non_any_chapter_votes!
+    migrate_production!(explicit_mappings: explicit_mappings)
+  end
+
+  def migrate_voter_in_chapter!
+    # Assign all votes for projects where the voter is in the chapter
+    votes = Vote
+              .where(chapter_id: nil)
+              .select(:id, Project.arel_table[:chapter_id])
+              .joins({ user: :roles }, :project)
+              .where(Role.arel_table[:chapter_id].eq(Project.arel_table[:chapter_id]))
+
+    update_votes(votes)
+  end
+
+  def migrate_any_chapter_votes!
+    # Assign all votes for projects in the Any chapter
+    votes = Vote.where(chapter_id: nil).joins(project: :chapter).merge(Project.where(chapter: Chapter.any_chapter))
+    votes_by_user = votes.each_with_object({}) { |v, memo| memo[v.user_id] ||= []; memo[v.user_id] << v }
+
+    ## For each vote, get all of the other votes for that user
+    ## If they're all the same, assign this vote to that chapter
+    votes_by_user.each do |user_id, user_votes|
+      user = User.find(user_id)
+
+      other_votes_chapters = user.votes.joins(project: :chapter).merge(Project.where.not(chapter: Chapter.any_chapter)).pluck(Project.arel_table[:chapter_id]).uniq
+      if other_votes_chapters.size == 1
+        puts "Updating User##{user_id} 'Any' chapter votes to Chapter##{other_votes_chapters.first} (#{user_votes.size} votes)"
+        Vote.where(id: user_votes.map(&:id)).update_all(chapter_id: other_votes_chapters.first)
+      elsif other_votes_chapters.empty? && user.chapters.size == 1
+        puts "User##{user_id} has no other votes and is in one chapter, assigning votes to Chapter##{user.chapters.first.id} (#{user_votes.size} votes)"
+        Vote.where(id: user_votes.map(&:id)).update_all(chapter_id: user.chapters.first.id)
+      else
+        puts "User##{user_id} had votes in chapters #{other_votes_chapters.inspect}, skipping."
+      end
+    end
+  end
+
+  def migrate_non_any_chapter_votes!
+    ## Get the votes that have not been assigned yet that are not part of the Any chapter
+    votes = Vote.where(chapter_id: nil).joins(project: :chapter).includes(project: :chapter).merge(Project.where.not(chapter: Chapter.any_chapter))
+    votes_by_user = votes.includes(:user).each_with_object({}) { |v, memo| memo[v.user] ||= []; memo[v.user] << v }
+
+    votes_by_user.each do |user, user_votes|
+      chapter_ids = user_votes.collect { |vote| vote.project.chapter_id }.uniq
+      if chapter_ids.size == 1
+        puts "User##{user.id} only has votes for Chapter##{chapter_ids.first}, assigning votes to that chapter (#{user_votes.size} votes)"
+        Vote.where(id: user_votes.map(&:id)).update_all(chapter_id: chapter_ids.first)
+      end
+    end
+  end
+
+  def migrate_production!(explicit_mappings: {})
+    # These user's votes should be associated with the user's main chapter
+    user_maps = explicit_mappings["user_to_chapter_maps"].to_a
+
+    user_maps.each do |user_id, chapter_id|
+      puts "Explicitly updating User##{user_id} vote chapters to Chapter##{chapter_id}"
+      Vote.where(chapter_id: nil, user_id: user_id).joins(:project).update_all(chapter_id: chapter_id)
+    end
+
+    # These Votes just need to be updated explicitly
+    explicit_mappings["vote_to_chapter_maps"].to_a.each do |vote_id, chapter_id|
+      puts "Explicitly updating Vote##{vote_id} to Chapter##{chapter_id}"
+      Vote.find(vote_id).update(chapter_id: chapter_id)
+    end
+
+    # These user's votes should be associated with the project's chapter
+    user_ids = explicit_mappings["project_chapter_user_ids"].to_a
+    any_chapter = Chapter.any_chapter
+
+    # Iterate over every vote and set the chapter_id to the project's chapter
+    # For the Any chapter, set the chapter to the previously seen real chapter
+    user_ids.each do |user_id|
+      puts "Explicitly updating User##{user_id} vote chapters to that project's chapter"
+      previous_chapter = nil
+      User.find(user_id).votes.joins(:project).includes(:project).order(:created_at).each do |vote|
+        if vote.project.chapter_id == any_chapter.id
+          vote.update(chapter_id: previous_chapter&.id) if vote.chapter_id.nil?
+        else
+          vote.update(chapter_id: vote.project.chapter.id) if vote.chapter_id.nil?
+          previous_chapter = vote.project.chapter
+        end
+      end
+    end
+  end
+
+  private
+
+  def update_votes(scope)
+    sql = <<-SQL
+      UPDATE votes SET chapter_id=votes_to_update.chapter_id
+      FROM (#{scope.to_sql}) AS votes_to_update
+      WHERE votes_to_update.id=votes.id
+    SQL
+
+    puts
+    puts sql
+
+    updated = ActiveRecord::Base.connection.update(Arel.sql(sql))
+
+    puts "#{updated} updated"
+    puts
+  end
+end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -1,8 +1,8 @@
 module ProjectsHelper
   def selectable_chapters_for(user)
-    any_chapter = Chapter.where(:name => "Any").first
+    any_chapter = Chapter.where(:name => Chapter::ANY_CHAPTER_NAME).first
     if user.admin?
-      [any_chapter] + Chapter.where("name != 'Any'").order(:name)
+      [any_chapter] + Chapter.where.not(name: Chapter::ANY_CHAPTER_NAME).order(:name)
     else
       [any_chapter] + user.chapters.order(:name)
     end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -16,6 +16,22 @@ module ProjectsHelper
     end
   end
 
+  def voting_chapters
+    return @voting_chapters if @voting_chapters
+
+    if current_user
+      @voting_chapters = current_user.chapters
+
+      if @voting_chapters.include?(@chapter)
+        @voting_chapters = [@chapter]
+      end
+    else
+      @voting_chapters = []
+    end
+
+    @voting_chapters
+  end
+
   def show_winner_buttons_for(project, options = {})
     if @chapter.any_chapter?
       winnable_chapters = current_user.dean_chapters

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -52,6 +52,14 @@ class Project < ApplicationRecord
       where("roles.user_id = #{user.id} OR chapters.name = ?", Chapter::ANY_CHAPTER_NAME)
   end
 
+  def self.with_votes_for_chapter(c)
+    where(id: Vote.where(chapter: c).select(:project_id))
+  end
+
+  def self.with_votes_by_members_of_chapter(c)
+    joins(:users).merge(User.where(id: c.users.select(:id)))
+  end
+
   def self.voted_for_by_members_of(chapter)
     joins(:users => :chapters).where("chapters.id = ? OR chapters.name = ?", chapter.id, Chapter::ANY_CHAPTER_NAME)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -49,11 +49,11 @@ class Project < ApplicationRecord
   def self.visible_to(user)
     joins(:chapter).
       joins("LEFT OUTER JOIN roles ON roles.chapter_id = chapters.id").
-      where("roles.user_id = #{user.id} OR chapters.name = 'Any'")
+      where("roles.user_id = #{user.id} OR chapters.name = ?", Chapter::ANY_CHAPTER_NAME)
   end
 
   def self.voted_for_by_members_of(chapter)
-    joins(:users => :chapters).where("chapters.id = #{chapter.id} OR chapters.name = 'Any'")
+    joins(:users => :chapters).where("chapters.id = ? OR chapters.name = ?", chapter.id, Chapter::ANY_CHAPTER_NAME)
   end
 
   def self.during_timeframe(start_date, end_date)

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,11 +1,15 @@
 class Vote < ApplicationRecord
   belongs_to :user
   belongs_to :project
+  belongs_to :chapter
 
   validates_presence_of :user_id
   validates_presence_of :project_id
+  validates_presence_of :chapter_id
 
   validates_uniqueness_of :user_id, :scope => :project_id
+
+  validate :ensure_chapter, on: :create
 
   def self.by(user)
     where(:user_id => user.id)
@@ -13,5 +17,13 @@ class Vote < ApplicationRecord
 
   def self.for(project)
     where(:project_id => project.id)
+  end
+
+  private
+
+  def ensure_chapter
+    unless user && user.chapters.include?(chapter)
+      self.errors.add(:chapter_id, :invalid_for_user)
+    end
   end
 end

--- a/app/views/finalists/index.html.erb
+++ b/app/views/finalists/index.html.erb
@@ -30,6 +30,11 @@
         <input class="string optional prefilled" id="filter_end" name="end" size="50" type="text" value="<%= @end_date %>" autocomplete="off">
       </div>
 
+      <div class="input toggle">
+        <%= check_box_tag "past_trustees", nil, params[:past_trustees].present? %>
+        <%= label_tag "past_trustees", t(".past-trustees-filter") %>
+      </div>
+
       <input name="" type="submit" value="<%= t(".filter-button") %>">
     </form>
   </section>

--- a/app/views/projects/_project_details.html.erb
+++ b/app/views/projects/_project_details.html.erb
@@ -4,9 +4,10 @@
 
     <div class="actions">
     <% if project.shortlisted_by?(current_user) %>
-      <%= link_to I18n.t(".awesome", scope: "projects.project"), project_vote_path(project), :method => :delete, :remote => true, :class => "short-list" %>
-    <% else %>
-      <%= link_to I18n.t(".awesome", scope: "projects.project"), project_vote_path(project), :method => :post, :remote => true, :class => "short-list" %>
+      <%= link_to I18n.t(".awesome", scope: "projects.project", count: 1), project_vote_path(project), :method => :delete, :remote => true, :class => "short-list", data: { chapter: "" } %>
+    <% end %>
+    <% voting_chapters.each do |voting_chapter| %>
+      <%= link_to I18n.t(".awesome", scope: "projects.project", count: voting_chapters.size, chapter: voting_chapter.slug), project_vote_path(project, chapter_id: voting_chapter.id), :method => :post, :remote => true, :class => "short-list", data: { chapter: voting_chapter.id } %>
     <% end %>
 
     <% if display_project_actions?(current_user, project) %>

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -113,7 +113,9 @@ bg:
   projects:
     wait-for-uploads-to-complete: Моля, изчакайте качването на изображенията да приключи, преди да изпратите кандидатурата.   
     project:
-      awesome: Awesome
+      awesome:
+        one: Awesome
+        other: Awesome (%{chapter})
       delete: Изтрий този проект
       see-the-rest: Виж останалите →
       view-public-page: Виж публичната сраница

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,7 @@ en:
       filter-button: Filter
       start-date: start date
       end-date: end date
+      past-trustees-filter: Include votes from past trustees
       table:
         title: Title
         id: ID
@@ -126,7 +127,9 @@ en:
     wait-for-uploads-to-complete: Please wait for your images to finish uploading before submitting your application.
 
     project:
-      awesome: Awesome
+      awesome:
+        one: Awesome
+        other: Awesome (%{chapter})
       delete: Delete this project
       see-the-rest: See the rest →
       view-public-page: View the public page
@@ -363,6 +366,10 @@ en:
           attributes:
             url:
               invalid: is not a valid website
+        vote:
+          attributes:
+            chapter_id:
+              invalid_for_user: is not valid for this user
   meta:
     description: Forwarding the interest of Awesome in the universe, $1,000 at a time.
   feed:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -123,7 +123,9 @@ es:
   projects:
     wait-for-uploads-to-complete: Por favor espera a que tus imágenes terminen de subir antes de someter tu solicitud.
     project:
-      awesome: Impresionante
+      awesome:
+        one: Impresionante
+        other: Impresionante (%{chapter})
       delete: Elimina este proyecto
       see-the-rest: Vea el resto  →
       view-public-page: Vea la página pública

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -113,7 +113,9 @@ fr:
   projects:
     wait-for-uploads-to-complete: "Veuillez attendre la fin du chargement de vos images pour envoyer votre candidature."
     project:
-      awesome: Awesome
+      awesome:
+        one: Awesome
+        other: Awesome (%{chapter})
       delete: Supprimer ce projet
       see-the-rest: Voir le reste →
       view-public-page: Voir la page publique

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -113,7 +113,9 @@
   projects:
     wait-for-uploads-to-complete: "Խնդրում ենք սպասել լուսանկարի բեռնման ավարտին նախքան Ձեր դիմումը ուղարկելը:"
     project:
-      awesome: Օսմ
+      awesome:
+        one: Օսմ
+        other: Օսմ (%{chapter})
       delete: Ջնջել այս նախագիծը
       see-the-rest: Դիտել մնացյալը →
       view-public-page: Դիտել հրապարակային էջը

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -113,7 +113,9 @@ pt:
   projects:
     wait-for-uploads-to-complete: Por favor aguarde o upload de suas imagens terminar antes de submeter seu application.
     project:
-      awesome: Awesome
+      awesome:
+        one: Awesome
+        other: Awesome (%{chapter})
       delete: Excluir este projeto
       see-the-rest: Veja mais →
       view-public-page: Ver a página pública

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -107,7 +107,9 @@ ru:
   projects:
     wait-for-uploads-to-complete: Пожалуйста, дождитесь пока ваши изображения загрузятся на наш сайт, после этого отправляйте вашу заявку.
     project:
-      awesome: Потрясающий
+      awesome:
+        one: Потрясающий
+        other: Потрясающий (%{chapter})
       delete: Удалить этот проект
       see-the-rest: Посмотреть остальное →
       view-public-page: Посмотреть общую страницу

--- a/db/migrate/20220304205611_add_votes_chapter.rb
+++ b/db/migrate/20220304205611_add_votes_chapter.rb
@@ -1,0 +1,5 @@
+class AddVotesChapter < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :votes, :chapter
+  end
+end

--- a/spec/controllers/finalists_controller_spec.rb
+++ b/spec/controllers/finalists_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe FinalistsController do
+  context '#index' do
+    let(:chapter) { FactoryGirl.create(:chapter) }
+    let(:project1) { FactoryGirl.create(:project, chapter: chapter) }
+    let(:project2) { FactoryGirl.create(:project, chapter: chapter) }
+    let(:trustee_role) { FactoryGirl.create(:role, :trustee, chapter: chapter) }
+    let(:past_trustee_role) { FactoryGirl.create(:role, :trustee, chapter: chapter) }
+    let!(:past_trustee) { past_trustee_role.user }
+
+    before do
+      Vote.create!(project: project1, user: trustee_role.user, chapter: chapter)
+      Vote.create!(project: project2, user: past_trustee, chapter: chapter)
+
+      past_trustee_role.destroy
+
+      sign_in_as trustee_role.user
+    end
+
+    render_views
+
+    it "only shows projects voted on by current trustees by default" do
+      get :index, params: { chapter_id: chapter }
+
+      expect(response.body).to have_selector("tr.finalist[data-id='#{project1.id}']")
+      expect(response.body).to_not have_selector("tr.finalist[data-id='#{project2.id}']")
+    end
+
+    it "shows projects voted on by all trustees when the past_trustees param is set" do
+      get :index, params: { chapter_id: chapter, past_trustees: "on" }
+
+      expect(response.body).to have_selector("tr.finalist[data-id='#{project1.id}']")
+      expect(response.body).to have_selector("tr.finalist[data-id='#{project2.id}']")
+    end
+  end
+end

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -9,7 +9,7 @@ describe VotesController do
   context "user can vote on a project" do
     before do
       sign_in_as user
-      post :create, params: { project_id: project.id }
+      post :create, params: { project_id: project.id, chapter_id: project.chapter.id }
     end
     it { is_expected.to respond_with(:success) }
     it { expect(response.header['Content-Type']).to include 'json' }
@@ -26,10 +26,10 @@ describe VotesController do
   end
 
   context "error when user votes for a second time on a project" do
-    let!(:vote) { FactoryGirl.create(:vote, :project => project, :user => user) }
+    let!(:vote) { FactoryGirl.create(:vote, project: project, user: user, chapter: project.chapter) }
     before do
       sign_in_as user
-      post :create, params: { project_id: project.id }
+      post :create, params: { project_id: project.id, chapter_id: project.chapter.id }
     end
     it { is_expected.to respond_with(400) }
     it { expect(response.header['Content-Type']).to include 'json' }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 FactoryGirl.define do
   sequence(:email) {|n| "user#{n}@example.com" }
   sequence(:title) {|n| "Something Awesome ##{n}" }
@@ -29,6 +30,10 @@ FactoryGirl.define do
         FactoryGirl.create(:role, :user => user, :name => "dean")
         user.reload
       end
+    end
+
+    factory :user_with_trustee_role do
+      chapters { [association(:chapter) ] }
     end
   end
 
@@ -70,8 +75,12 @@ FactoryGirl.define do
   end
 
   factory :vote do
-    user
+    association :user, factory: :user_with_trustee_role
     project
+
+    after(:build) do |vote|
+      vote.chapter ||= vote.user.chapters.first
+    end
   end
 
   factory :photo do

--- a/spec/features/step_definitions/finalist_steps.rb
+++ b/spec/features/step_definitions/finalist_steps.rb
@@ -54,3 +54,7 @@ end
 step 'I should see the project I shortlisted' do
   expect(page).to have_css("tr.finalist[data-id='#{@shortlisted_project_id}']")
 end
+
+step 'I should not see the project I shortlisted' do
+  expect(page).to_not have_css("tr.finalist[data-id='#{@shortlisted_project_id}']")
+end

--- a/spec/features/step_definitions/shortlist_steps.rb
+++ b/spec/features/step_definitions/shortlist_steps.rb
@@ -2,7 +2,7 @@ step 'I shortlist a project' do
   # just choose the first project
   project_element = page.find(:css, "article.project", match: :first)
   @shortlisted_project_id = project_element['data-id'].to_i
-  project_element.find(:css, "header a.short-list").click
+  project_element.find(:css, "header a.short-list[data-chapter='#{@current_chapter.id}']").click
 end
 
 step 'I shortlist a project on the second page' do
@@ -42,8 +42,8 @@ step ':count people/person have/has voted on a/another project in my chapter' do
   project = FactoryGirl.create(:project, :chapter => @current_chapter, :created_at => count.to_i.days.ago)
   @finalist_projects << [project, count] if count.to_i > 0
   count.to_i.times do |x|
-    vote = FactoryGirl.create(:vote, :project => project, :created_at => x.days.ago)
-    FactoryGirl.create(:role, :user => vote.user, :chapter => @current_chapter)
+    role = FactoryGirl.create(:role, :chapter => @current_chapter)
+    vote = FactoryGirl.create(:vote, :user => role.user, :project => project, :chapter => @current_chapter, :created_at => x.days.ago)
   end
 end
 
@@ -51,7 +51,7 @@ step 'there are some projects for this month with votes' do
   role = FactoryGirl.create(:role, :chapter => @current_chapter)
   3.times do
     project = FactoryGirl.create(:project, :chapter => @current_chapter)
-    FactoryGirl.create(:vote, :user => role.user, :project => project)
+    FactoryGirl.create(:vote, :user => role.user, :project => project, :chapter => @current_chapter)
   end
 end
 
@@ -60,7 +60,7 @@ step 'there are some projects in the "Any" chapter for this month with votes' do
   role = FactoryGirl.create(:role, :chapter => @current_chapter)
   3.times do
     project = FactoryGirl.create(:project, :chapter => @any_chapter)
-    FactoryGirl.create(:vote, :user => role.user, :project => project)
+    FactoryGirl.create(:vote, :user => role.user, :project => project, :chapter => @current_chapter)
   end
 end
 

--- a/spec/features/trustee_shortlists_projects.feature
+++ b/spec/features/trustee_shortlists_projects.feature
@@ -36,7 +36,7 @@ Feature: A trustee can see all of the projects up for discussion and shortlist t
     And I shortlist a project
     Then the project indicates that I have shortlisted it
     When I look at the other chapter's finalists
-    Then I should see the project I shortlisted
+    Then I should not see the project I shortlisted
     When I look at my chapter's finalists
     Then I should see the project I shortlisted
 

--- a/spec/lib/project_filter_spec.rb
+++ b/spec/lib/project_filter_spec.rb
@@ -29,8 +29,8 @@ describe ProjectFilter do
     shortlisted_project = FactoryGirl.create(:project, :chapter => chapter)
     project = FactoryGirl.create(:project, :chapter => chapter)
     user = FactoryGirl.create(:user_with_dean_role, :chapters => [chapter])
-    FactoryGirl.create(:vote, :user => user, :project => shortlisted_project)
-    FactoryGirl.create(:vote, :user => FactoryGirl.create(:user), :project => shortlisted_project)
+    FactoryGirl.create(:vote, :user => user, :project => shortlisted_project, :chapter => chapter)
+    FactoryGirl.create(:vote, :user => FactoryGirl.create(:user, chapters: [chapter]), :project => shortlisted_project, :chapter => chapter)
 
     project_filter = ProjectFilter.new(Project)
     expect(project_filter.shortlisted_by(user).result).to eq([shortlisted_project])

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -5,8 +5,10 @@ describe Vote do
     before { FactoryGirl.create(:vote) }
     it { is_expected.to belong_to :user }
     it { is_expected.to belong_to :project }
+    it { is_expected.to belong_to :chapter }
     it { is_expected.to validate_presence_of :user_id }
     it { is_expected.to validate_presence_of :project_id }
+    it { is_expected.to validate_presence_of :chapter_id }
     it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:project_id) }
   end
 
@@ -23,6 +25,22 @@ describe Vote do
     let!(:other_vote) { FactoryGirl.create(:vote) }
     it 'returns the votes for a certain project' do
       expect(Vote.for(vote.project)).to eq([vote])
+    end
+  end
+
+  context "chapter" do
+    let(:vote) { FactoryGirl.build(:vote) }
+    let(:other_chapter) { FactoryGirl.create(:chapter) }
+
+    it "can be one of the user's chapters" do
+      vote.valid?
+      expect(vote.errors).to be_empty
+    end
+
+    it "can not be a chapter the user is not a member of" do
+      vote.chapter = other_chapter
+      vote.valid?
+      expect(vote.errors[:chapter_id].first).to eq(I18n.t("activerecord.errors.models.vote.attributes.chapter_id.invalid_for_user"))
     end
   end
 end

--- a/spec/views/finalists_views_spec.rb
+++ b/spec/views/finalists_views_spec.rb
@@ -2,19 +2,20 @@ require 'spec_helper'
 
 describe 'finalists/index' do
   let!(:user) { FactoryGirl.create(:user_with_dean_role) }
-  let!(:project1) { FactoryGirl.create(:project) }
+  let!(:project1) { FactoryGirl.create(:project, chapter: user.chapters.first) }
   let!(:project2) { FactoryGirl.create(:project) }
 
   describe 'when a project from another chapter has votes from our trustees' do
     it 'displays the name of the other chapter next to that project title' do
-      Vote.create(user: user, project: project1)
-      Vote.create(user: user, project: project2)
+      Vote.create(user: user, project: project1, chapter: project1.chapter)
+      Vote.create(user: user, project: project2, chapter: project1.chapter)
 
       assign(:chapter, project1.chapter)
-      assign(:projects, Project.by_vote_count)
+      assign(:projects, Project.with_votes_for_chapter(project1.chapter).by_vote_count)
       view.stubs(:current_user).returns(user)
 
       render
+
       expect(rendered).not_to have_css("tr[data-id=\"#{project1.id}\"] td em", text: project1.chapter.display_name)
       expect(rendered).to have_css("tr[data-id=\"#{project2.id}\"] td em", text: project2.chapter.display_name)
     end


### PR DESCRIPTION
This has traditionally led to a few different problems:

- a user is in multiple chapters so the finalists page doesn't know which chapter the user intended the vote to be attached to
- a user moves chapters and "carries" all of their old votes over to the new chapter
- a user leaves a chapter and now the finalists page doesn't show  historical project votes (since project votes to this point have  been tied to current chapter members)

This change adds a Vote#chapter_id which is the chapter that the vote is tied to, at the time of voting. Even if a user leaves a chapter, the vote is still attached to the chapter for future reference. And if a user is in multiple chapters simultaneously then when they vote, they have multiple buttons and they can choose which chapter they are voting for.

A user still can not vote for the same project multiple times in multiple chapters. This is such an edge case that it wasn't worth trying to figure out.

After running the migration, we must run `VoteMigrator.new.migrate!` as a one-time conversion to to add the chapter_id to all existing votes.

There is a logic to this migration (because of the above issues, it is not always obvious which chapter a vote should be associated with). 

You can also pass in an array of explicit mappings of 1) user -> chapter explicit mappings 2) vote -> chapter explicit mappings 3) users for which the chapter_id is just the chapter_id of the project being voted on (see the code for the exact format of what's needed).