### PR TITLE
Add support for imgproxy

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -78,7 +78,13 @@ class Photo < ApplicationRecord
   end
 
   def cropped_image_url(crop)
-    cropper = ENV['THUMBOR_HOST'] ? :thumbor : :magickly
+    cropper = if ENV['IMGPROXY_HOST']
+                :imgproxy
+              elsif ENV['THUMBOR_HOST']
+                :thumbor
+              else
+                :magickly
+              end
     ImageCropper.new(cropper, self).crop_url(crop)
   end
 


### PR DESCRIPTION
[imgproxy](https://imgproxy.net/) is a faster, more modern solution to dynamically resize image vs magickly which is the current default. This should allow us to handle heic/heif images and hopefully process GIFs better as well.