### PR TITLE
FundedProjects#index displays properly when there are fewer than 3 results

### DIFF
--- a/app/assets/stylesheets/_funded-projects.scss
+++ b/app/assets/stylesheets/_funded-projects.scss
@@ -2,6 +2,10 @@
     max-width: none;
 }
 
+.funded_projects-index .container {
+    width: 100%;
+}
+
 .filters-wrapper {
     background: rgb(230,230,230);
     border: 1px solid rgb(200,200,200);


### PR DESCRIPTION
Results were not stretching to the full page width when there weren't enough projects to stretch the container.

Broken:
![Screenshot 2022-10-08 at 23-03-30 Projects (laboriosam) - Melbourne](https://user-images.githubusercontent.com/2909/194735755-fb5f715f-c086-4802-8a13-b392397ba5b5.png)

Fixed:
![Screenshot 2022-10-08 at 23-04-55 Projects (laboriosam) - Melbourne](https://user-images.githubusercontent.com/2909/194735790-d8d9fa57-e97b-48c8-81b3-35e3090edfa0.png)
