### PR TITLE
Step one of Paperclip to Shrine migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', '5.2.8.1'
 gem 'rake', '< 13.0'
 gem 'bootsnap','>= 1.1.0', require: false
 
+gem 'aws-sdk-s3'
 gem 'puma'
 gem 'pg', '~> 0.20.0'
 gem 'textacular', '~> 5.1.0'
@@ -34,6 +35,7 @@ gem 'rack-cors'
 gem 'rack-ssl-enforcer'
 gem 'rollbar'
 gem 'sassc-rails', '~> 2.1'
+gem 'shrine', '~> 3'
 gem 'coffee-rails'
 gem 'uglifier'
 gem 'react-rails'
@@ -44,6 +46,7 @@ group :development do
   gem "letter_opener"
   gem "listen"
   gem 'web-console'
+  gem "dotenv-rails"
 end
 
 group :development, :test do
@@ -52,13 +55,13 @@ group :development, :test do
   gem "sham_rack"
   gem "pry"
   gem "pry-nav"
-  gem "dotenv-rails"
 end
 
 group :test do
   gem "turnip"
   gem "capybara", "~> 2.18.0"
   gem "capybara-screenshot", "~> 1.0.11"
+  gem "climate_control"
   gem "webdrivers"
   gem "database_cleaner"
   gem "factory_girl_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,8 +42,25 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.2.8)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     arel (9.0.0)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.646.0)
+    aws-sdk-core (3.160.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.58.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.114.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -96,6 +113,7 @@ GEM
     columnize (0.8.9)
     concurrent-ruby (1.1.10)
     connection_pool (2.2.2)
+    content_disposition (1.0.0)
     crass (1.0.6)
     database_cleaner (1.7.0)
     debugger-linecache (1.2.0)
@@ -103,6 +121,8 @@ GEM
     dotenv (1.0.2)
     dotenv-rails (1.0.2)
       dotenv (= 1.0.2)
+    down (5.3.1)
+      addressable (~> 2.8)
     email_spec (1.6.0)
       launchy (~> 2.1)
       mail (~> 2.2)
@@ -152,6 +172,7 @@ GEM
       actionpack (>= 3.0.0)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    jmespath (1.6.1)
     jquery-fileupload-rails (0.4.1)
       actionpack (>= 3.1)
       railties (>= 3.1)
@@ -162,10 +183,10 @@ GEM
     jquery-ui-rails (3.0.1)
       jquery-rails
       railties (>= 3.1.0)
-    launchy (2.1.0)
-      addressable (~> 2.2.6)
-    letter_opener (1.0.0)
-      launchy (>= 2.0.4)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -206,6 +227,7 @@ GEM
       slop (>= 2.4.4, < 3)
     pry-nav (0.2.1)
       pry (~> 0.9.9)
+    public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -318,6 +340,9 @@ GEM
       rack
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    shrine (3.4.0)
+      content_disposition (~> 1.0)
+      down (~> 5.1)
     simple_form (4.1.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -369,6 +394,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap (>= 1.1.0)
   bourbon (~> 4.0.2)
   bourne
@@ -377,6 +403,7 @@ DEPENDENCIES
   capybara-screenshot (~> 1.0.11)
   clearance (~> 1.13.0)
   clearance-deprecated_password_strategies
+  climate_control
   coffee-rails
   database_cleaner
   dotenv-rails
@@ -420,6 +447,7 @@ DEPENDENCIES
   selenium-webdriver
   sham_rack
   shoulda-matchers
+  shrine (~> 3)
   simple_form (~> 4.1)
   sprockets-redirect
   sucker_punch (~> 1.0)

--- a/app/extras/paperclip_shrine_sync.rb
+++ b/app/extras/paperclip_shrine_sync.rb
@@ -1,0 +1,85 @@
+# require "shrine"
+# require "shrine/storage/file_system"
+
+# Shrine.storages = {
+#   cache: Shrine::Storage::FileSystem.new("public", prefix: "uploads/cache"), # temporary
+#   store: Shrine::Storage::FileSystem.new("public", prefix: "uploads"),       # permanent 
+# }
+
+# Shrine.plugin :model
+# Shrine.plugin :activerecord
+# Shrine.plugin :derivatives
+
+module PaperclipShrineSync
+  def self.included(model)
+    model.after_commit do
+      Paperclip::AttachmentRegistry.each_definition do |klass, name, options|
+        write_shrine_data(name) if saved_changes.key?(:"#{name}_file_name") && klass == self.class
+      end
+    end
+  end
+
+  def write_shrine_data(name)
+    attachment = send(name)
+    attacher   = ImageUploader::Attacher.from_model(self, name)
+
+    if attachment.size.present?
+      attacher.set shrine_file(attachment)
+
+      attachment.styles.each do |style_name, style|
+        attacher.merge_derivatives(style_name => shrine_file(style))
+      end
+    else
+      attacher.set nil
+    end
+
+    attacher.send(:activerecord_after_save)
+  end
+
+  private
+
+  def shrine_file(object)
+    if object.is_a?(Paperclip::Attachment)
+      shrine_attachment_file(object)
+    else
+      shrine_style_file(object)
+    end
+  end
+
+  def shrine_attachment_file(attachment)
+    location = attachment.path
+    # if you're storing files on disk, make sure to subtract the absolute path
+    location = location.sub(%r{^#{storage.prefix}/}, "") if storage.try(:prefix)
+    location = location.sub(%r{^#{Shrine.storages[:store].directory}/}, "") if Shrine.storages[:store].respond_to?(:directory)
+
+    Shrine.uploaded_file(
+      storage:  :store,
+      id:       location,
+      metadata: {
+        "size"      => attachment.size,
+        "filename"  => attachment.original_filename,
+        "mime_type" => attachment.content_type,
+      }
+    )
+  end
+
+  # If you'll be using a `:prefix` on your Shrine storage, or you're storing
+  # files on the filesystem, make sure to subtract the appropriate part
+  # from the path assigned to `:id`.
+  def shrine_style_file(style)
+    location = style.attachment.path(style.name)
+    # if you're storing files on disk, make sure to subtract the absolute path
+    location = location.sub(%r{^#{storage.prefix}/}, "") if storage.try(:prefix)
+    location = location.sub(%r{^#{Shrine.storages[:store].directory}/}, "") if Shrine.storages[:store].respond_to?(:directory)
+
+    Shrine.uploaded_file(
+      storage:  :store,
+      id:       location,
+      metadata: {},
+    )
+  end
+
+  def storage
+    Shrine.storages[:store]
+  end
+end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,4 +1,7 @@
 class Photo < ApplicationRecord
+  # TODO All this code can be removed once we migrate to Shrine
+  cattr_accessor :shrine_uploads, default: ENV["SHRINE_UPLOADS"]
+
   DIMENSIONS = {
     main:            "940x470",
     index:           "500x300",
@@ -12,15 +15,23 @@ class Photo < ApplicationRecord
   MAX_FILE_SIZE = 20.megabytes
 
   scope :sorted, -> { order(sort_order: :asc, id: :asc) }
-  scope :image_files, -> { where(Photo.arel_table[:image_content_type].matches('image/%')) }
+  scope :image_files, -> { where(Photo.arel_table[:image_content_type].matches('image/%')).or(where(Arel.sql("image_data->'metadata'->>'mime_type' LIKE 'image/%'"))) }
 
   belongs_to :project, optional: true
-  has_attached_file :image,
-                    default_url: "no-image-:style.png"
 
-  # Added when migrating to Paperclip 4.1 and since Paperclip
-  # is deprecated, we will handle content validations later
-  do_not_validate_attachment_file_type :image
+  if shrine_uploads
+    include ImageUploader::Attachment(:image)
+  else
+    has_attached_file :image,
+                      default_url: "no-image-:style.png"
+
+    # https://shrinerb.com/docs/paperclip
+    include PaperclipShrineSync
+
+    # Added when migrating to Paperclip 4.1 and since Paperclip
+    # is deprecated, we will handle content validations later
+    do_not_validate_attachment_file_type :image
+  end
 
   after_create do
     DirectUploadJob.new.async.perform(self)
@@ -30,14 +41,14 @@ class Photo < ApplicationRecord
   self.fog_config = Rails.configuration.fog
 
   def image?
-    image_content_type.to_s.match?(/^image\//)
+    image && image.content_type.to_s.match?(/^image\//)
   end
 
   # Build a URL to dynamically resize application images via an external service
   # Currently using http://magickly.afeld.me/
   def url(size = nil)
     if crop = DIMENSIONS[size]
-      image.present? ? cropped_image_url(crop) : image.url(size)
+      image.present? ? cropped_image_url(crop) : (shrine_uploads ? image_attacher.url(derivative: size) : image.url(size))
 
     else
       image_url
@@ -47,6 +58,11 @@ class Photo < ApplicationRecord
   def transfer_from_direct_upload
     if persisted? && direct_upload_url.present?
       set_attributes_from_direct_upload
+
+      if shrine_uploads
+        # self.direct_upload_url = nil
+        save && return
+      end
 
       if uploaded_file = bucket.files.head(direct_upload_path)
         uploaded_file.copy(fog_config.bucket, image.path)
@@ -78,7 +94,11 @@ class Photo < ApplicationRecord
   protected
 
   def image_url
-    image.url(:original, :timestamp => false)
+    if shrine_uploads
+      super
+    else
+      image.url(:original, :timestamp => false)
+    end
   end
 
   def cropped_image_url(crop)
@@ -103,10 +123,25 @@ class Photo < ApplicationRecord
   def set_attributes_from_direct_upload
     file = bucket.files.head(direct_upload_path)
 
-    self.image_file_name = File.basename(direct_upload_path).gsub(image.options[:restricted_characters], "_")
-    self.image_content_type = file.content_type
-    self.image_file_size = file.content_length
-    self.image_updated_at = file.last_modified
+    if shrine_uploads
+      location = direct_upload_path
+      location.sub!(%r{^#{Shrine.storages[:cache].prefix}/}, "") if Shrine.storages[:cache].try(:prefix)
+
+      image_attacher.change Shrine.uploaded_file(
+        storage: :cache,
+        id: location,
+        metadata: {
+          size: file.content_length,
+          filename: File.basename(direct_upload_path),
+          mime_type: file.content_type
+        }
+      )
+    else
+      self.image_file_name = File.basename(direct_upload_path).gsub(image.options[:restricted_characters], "_")
+      self.image_content_type = file.content_type
+      self.image_file_size = file.content_length
+      self.image_updated_at = file.last_modified
+    end
   end
 
   # S3 URLs come in with spaces escaped, so we have to unescape them to get the

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,67 @@
+class ImageUploader < Shrine
+  ID_PARTITION_LIMIT = 1_000_000_000
+  
+  plugin :model
+  plugin :activerecord
+  plugin :default_url
+
+  Attacher.default_url do |derivative: nil, **|
+    "no-image-#{derivative || "original"}.png"
+  end
+
+  def generate_location(io, record: nil, name: nil, derivative: nil, metadata: {}, **)
+    return super unless storage_key == :store
+    
+    # photos/images/id/original/file
+
+    if Shrine.storages[storage_key].is_a?(Shrine::Storage::S3)
+      [
+        record && record.class.name.underscore.pluralize,
+        name.to_s.pluralize,
+        record && record.id,
+        derivative || "original",
+        sanitize_name(io.original_filename)
+      ].compact.join("/")
+
+    else
+      # public/system/photos/images/000/000/120/original/duck.0.jpg 
+      [
+        record && record.class.name.underscore.pluralize,
+        name.to_s.pluralize,
+        record && partitioned_id(record.id),
+        derivative || "original",
+        basic_location(io, metadata: metadata)
+      ].compact.join("/")
+    end
+  end
+
+  class Attacher
+
+    private
+    
+    def activerecord_after_save
+      super
+
+      record.update_columns(
+        image_file_name: File.basename(record.image.id),
+        image_content_type: record.image.mime_type,
+        image_file_size: record.image.size,
+        image_updated_at: Time.current
+      ) if record.image.present? && record.image.is_a?(Shrine::UploadedFile)
+    end
+  end
+
+  private
+
+  def sanitize_name(name)
+    name&.gsub(/[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/, '_')
+  end
+  
+  def partitioned_id(id)
+    if id < ID_PARTITION_LIMIT
+      ("%09d".freeze % id).scan(/\d{3}/).join("/".freeze)
+    else
+      ("%012d".freeze % id).scan(/\d{3}/).join("/".freeze)
+    end
+  end
+end

--- a/app/views/projects/_image_upload.html.erb
+++ b/app/views/projects/_image_upload.html.erb
@@ -6,7 +6,7 @@
         <%= form.input :photo_order, as: :hidden %>
         <% form.object.photos.each do |photo| %>
           <li data-id="<%= photo.id %>">
-            <span><%= photo.image_file_name %></span>
+            <span><%= photo.image.original_filename %></span>
             <a href="#" class="remove-image" data-remove="true">remove</a>
           </li>
         <% end %>

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -1,0 +1,34 @@
+require "shrine"
+require "shrine/storage/file_system"
+require "shrine/storage/memory"
+require "shrine/storage/s3"
+
+Shrine.plugin :instrumentation
+Shrine.logger = Rails.logger
+
+if Rails.env.test?
+  Shrine.storages = {
+    cache: Shrine::Storage::Memory.new,
+    store: Shrine::Storage::Memory.new
+  }
+
+elsif Rails.env.development? && !ENV["AWS_BUCKET"]
+  Shrine.storages = {
+    cache: Shrine::Storage::FileSystem.new("public", prefix: "system/cache"),
+    store: Shrine::Storage::FileSystem.new("public", prefix: "system")
+  }
+
+else
+  s3_options = {
+    bucket: ENV["AWS_BUCKET"],
+    region: ENV["AWS_REGION"] || "us-east-1",
+    access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+    secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]
+  }
+  
+  Shrine.storages = {
+    cache: Shrine::Storage::S3.new(prefix: "uploads", **s3_options),
+    store: Shrine::Storage::S3.new(public: true, **s3_options)
+    
+  }
+end

--- a/db/migrate/20221017040918_add_shrine.rb
+++ b/db/migrate/20221017040918_add_shrine.rb
@@ -1,0 +1,5 @@
+class AddShrine < ActiveRecord::Migration[5.2]
+  def change
+    add_column :photos, :image_data, :jsonb
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,11 @@ services:
       APPLICATION_IMAGE_PREVIEWS: true
       DB_NAME: postgres
       DEFAULT_URL: http://host.docker.internal:3000
+      IMGPROXY_HOST: //localhost:8080
       POSTGRES_HOST: db
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: mysecretpassword
-      IMGPROXY_HOST: //localhost:8080
+      SHRINE_UPLOADS:
     depends_on:
       - db
 


### PR DESCRIPTION
- Add code to populate Shrine's image_data when Paperclip uploads a file
- Add code that can retroactively add image_data to all old Photos
- Add SHRINE_UPLOADS envinronment variable that will let us flip to Shrine

Paperclip has been deprecated since 2018 and is no longer receiving updates. While the recommended upgrade path is ActiveStorage, this would require moving all of our existing assets on S3 to new locations to conform with the ActiveStorage paradigm. Shrine is another file uploading library that will let us leave our existing images in place, and has other nice things for the future, like built-in pre-signed URLs for direct S3 uploads.

https://thoughtbot.com/blog/closing-the-trombone