### PR TITLE
BUGFIX: Submitting incomplete form with images caused page crash

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -91,6 +91,10 @@ class Photo < ApplicationRecord
     uri.to_s
   end
 
+  def original_filename
+    image&.original_filename || (direct_upload_url && File.basename(direct_upload_url))
+  end
+
   protected
 
   def image_url

--- a/app/views/projects/_image_upload.html.erb
+++ b/app/views/projects/_image_upload.html.erb
@@ -6,8 +6,13 @@
         <%= form.input :photo_order, as: :hidden %>
         <% form.object.photos.each do |photo| %>
           <li data-id="<%= photo.id %>">
-            <span><%= photo.image.original_filename %></span>
+            <span><%= photo.original_filename %></span>
             <a href="#" class="remove-image" data-remove="true">remove</a>
+            <% unless photo.persisted? %>
+              <% if photo.direct_upload_url.present? %>
+                <%= hidden_field_tag "project[new_photo_direct_upload_urls][]", photo.direct_upload_url %>
+              <% end %>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -161,6 +161,19 @@ describe ProjectsController do
 
   end
 
+  context "creating a project submission" do
+    context "when incomplete but with an image" do
+      render_views
+
+      before do
+        post :create, params: { project: { new_photo_direct_upload_urls: ["http://example.com/test.png"] } }
+      end
+
+      it { is_expected.to respond_with(:success) }
+      it { is_expected.to render_template("new") }
+    end
+  end
+
   describe "#hide" do
     let(:user) { FactoryGirl.create(:user) }
     let(:reason) { Faker::Company.bs }


### PR DESCRIPTION
Trying to call original_filename on the non-persisted image was causing issues. Instead, we should display the filename from the upload that has already been uploaded to S3 and add that as a hidden field so the image is properly submitted when the application does go through.

This was introduced when we added shrine in #498 