### PR TITLE
Switch from :must_be_logged_in to :require_login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   def must_be_logged_in
     if current_user.blank? || !current_user.logged_in?
-      flash[:notice] = t("flash.permissions.must-be-logged-in")
+      flash[:notice] = t("flashes.failure_when_not_signed_in")
       redirect_to root_url
     end
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,5 +1,5 @@
 class InvitationsController < ApplicationController
-  before_action :must_be_logged_in
+  before_action :require_login
   before_action :must_be_able_to_invite
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,5 @@
 class ProjectsController < ApplicationController
-  before_action :must_be_logged_in, except: [:new, :create, :success]
+  before_action :require_login, except: [:new, :create, :success]
   before_action :verify_user_can_edit, :only => [:destroy]
   before_action :redirect_to_chapter_or_sign_in, :only => [:index], :if => :chapter_missing?
   before_action :find_chapter, :only => [:index, :show]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :must_be_logged_in
+  before_action :require_login
   before_action :ensure_chapter, :only => [:index]
   before_action :ensure_current_user_or_admin, :only => [:update, :edit]
 

--- a/app/controllers/winners_controller.rb
+++ b/app/controllers/winners_controller.rb
@@ -1,5 +1,5 @@
 class WinnersController < ApplicationController
-  before_action :must_be_logged_in
+  before_action :require_login
   before_action :must_be_able_to_mark_winner, only: [:create, :update, :destroy]
 
   def create

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -12,7 +12,6 @@ bg:
     facebook: Facebook
   flash:
     permissions:
-      must-be-logged-in: Влезте в профила си.
       must-be-admin: Трябва да сте админ.
       cannot-remove-user: Не може да премахнете този потребител.
       must-be-dean-or-admin: Трябва да сте админ или декан, за да влезнете.
@@ -31,6 +30,8 @@ bg:
       cannot: "Неуспешно приемане на поканата"
     projects:
       hide-reason-required: Трабва да индикирате защо скривате проект
+  flashes:
+    failure_when_not_signed_in: Влезте в профила си.
   layouts:
     application:
       main-header: The Awesome Foundation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,6 @@ en:
     monthly: Monthly
   flash:
     permissions:
-      must-be-logged-in: You must be logged in.
       must-be-admin: You must be an administrator.
       cannot-remove-user: You are not allowed to remove this user.
       must-be-dean-or-admin: You must be an admin or dean to access this page.
@@ -33,6 +32,8 @@ en:
     projects:
       hide-reason-required: You must supply a reason a to hide a project
       error: There was a problem saving your project
+  flashes:
+    failure_when_not_signed_in: You must be logged in.
   layouts:
     application:
       main-header: The Awesome Foundation

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -12,7 +12,6 @@ es:
     facebook: Facebook
   flash:
     permissions:
-      must-be-logged-in: Debes estar conectado.
       must-be-admin: Debes ser un administrador.
       cannot-remove-user: No tienes permiso para remover a este usuario.
       must-be-dean-or-admin: Debes ser un administrador o decano para tener acceso a esta página.
@@ -31,6 +30,8 @@ es:
       cannot: "La invitación no fue aceptada"
     projects:
       hide-reason-required: Usted deberá proveer una razón para esconder un proyecto
+  flashes:
+    failure_when_not_signed_in: Debes estar conectado.
   layouts:
     application:
       main-header: The Awesome Foundation

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -12,7 +12,6 @@ fr:
     facebook: Facebook
   flash:
     permissions:
-      must-be-logged-in: Vous devez être connecté.
       must-be-admin: Vous devez être administrateur.
       cannot-remove-user: Vous n'êtes pas autorisé à retirer cet utilisateur.
       must-be-dean-or-admin: Vous devez être administrateur ou doyen pour accéder à cette page.
@@ -31,6 +30,8 @@ fr:
       cannot: "Ne peut pas accepter l'invitation"
     projects:
       hide-reason-required: Vous devez donner une raison pour masquer un projet
+  flashes:
+    failure_when_not_signed_in: Vous devez être connecté.
   layouts:
     application:
       main-header: L'Awesome Foundation

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -12,7 +12,6 @@
     facebook: Facebook
   flash:
     permissions:
-      must-be-logged-in: "Դուք պետք է գրանցված լինեք:"
       must-be-admin: "Դուք պետք է ադմինիստրատոր լինեք:"
       cannot-remove-user: "Դուք իրավունք չունեք հեռացնել այս օգտատիրոջը:"
       must-be-dean-or-admin: "Դուք պետք է ադմինիստրատոր կամ դեկան լինեք, որպեսզի մուտք գործեք այս էջ:"
@@ -31,6 +30,8 @@
       cannot: "Չի կարող ընդունել հրավերը"
     projects:
       hide-reason-required: "Դուք պետք է ներկայացնեք նախագիծը թաքցնելու պատճառը:"
+  flashes:
+    failure_when_not_signed_in: "Դուք պետք է գրանցված լինեք:"
   layouts:
     application:
       main-header: Օսմ հիմնադրամ

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -12,7 +12,6 @@ pt:
     facebook: Facebook
   flash:
     permissions:
-      must-be-logged-in: Você deve estar autenticado.
       must-be-admin: Você deve ser um administrador.
       cannot-remove-user: Você não tem permissão para remover este usuário.
       must-be-dean-or-admin: Você deve ser um administrador ou decano para acessar esta página.
@@ -31,6 +30,8 @@ pt:
       cannot: "Não foi possível aceitar o convite"
     projects:
       hide-reason-required: Você deve apresentar uma razão para esconder um projeto
+  flashes:
+    failure_when_not_signed_in: Você deve estar autenticado.
   layouts:
     application:
       main-header: The Awesome Foundation

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -12,7 +12,6 @@ ru:
     facebook: Facebook
   flash:
     permissions:
-      must-be-logged-in: Вы должны авторизоваться.
       must-be-admin: Вы должны быть администратором.
       cannot-remove-user: Вы не можете удалить этого пользователя.
       must-be-dean-or-admin: Только администратор или декан может просматривать эту страницу.
@@ -28,6 +27,8 @@ ru:
       thanks: "Спасибо за Вашу заявку!"
     acceptances:
       cannot: "Приглашение не может быть получено"
+  flashes:
+    failure_when_not_signed_in: Вы должны авторизоваться.
   layouts:
     application:
       main-header: Потрясающая организация

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -8,9 +8,9 @@ describe InvitationsController do
       before do
         get :new
       end
-      it { is_expected.to redirect_to(root_path) }
+      it { is_expected.to redirect_to(sign_in_path) }
       it 'sets the flash' do
-        expect(flash[:notice]).to eq("You must be logged in.")
+        expect(flash[:alert]).to eq(I18n.t("flashes.failure_when_not_signed_in"))
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -20,7 +20,7 @@ describe ProjectsController do
       get :index
     end
 
-    it { is_expected.to redirect_to(root_path) }
+    it { is_expected.to redirect_to(sign_in_path) }
   end
 
   context 'viewing the index with a search term' do
@@ -93,7 +93,7 @@ describe ProjectsController do
         get :show, params: { chapter_id: project.chapter, id: project }
       end
 
-      it { is_expected.to redirect_to root_path }
+      it { is_expected.to redirect_to sign_in_path }
     end
 
     context "while logged in as a trustee" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -24,6 +24,6 @@ describe UsersController do
       sign_out
       get :index
     end
-    it { is_expected.to redirect_to(root_url) }
+    it { is_expected.to redirect_to(sign_in_path) }
   end
 end

--- a/spec/controllers/winners_controller_spec.rb
+++ b/spec/controllers/winners_controller_spec.rb
@@ -14,7 +14,8 @@ describe WinnersController do
       get :edit, params: { chapter_id: project.chapter_id, project_id: project.id }
 
       expect(response.status).to eq(302)
-      expect(flash[:notice]).to eq(I18n.t("flash.permissions.must-be-logged-in"))
+      expect(response).to redirect_to(sign_in_path)
+      expect(flash[:alert]).to eq(I18n.t("flashes.failure_when_not_signed_in"))
     end
   end
 


### PR DESCRIPTION
:require_login is a Clearance built-in function which will redirect to the sign-in page and then back to the page we were originally trying to reach.

Not switching VotesController and CommentsController for now since these both operate completely via AJAX and should probably have a different interface (or at least a specific response type handler).

Closes https://github.com/awesomefoundation/awesomebits/issues/507