### PR TITLE
BUGFIX: properly handle cached image uploads on application validation error

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -3,6 +3,7 @@ class ImageUploader < Shrine
   
   plugin :model
   plugin :activerecord
+  plugin :cached_attachment_data
   plugin :default_url
   plugin :default_storage
 

--- a/app/views/projects/_image_form_element.html.erb
+++ b/app/views/projects/_image_form_element.html.erb
@@ -2,7 +2,7 @@
   <a href="#" class="remove-image" data-remove="true">remove</a>
   <%= image_tag(photo.url(:small_square), title: photo.original_filename, class: "form__image-element-image") %>
   <%= f.input :caption, as: :string, input_html: { class: "form__image-element-caption", autocomplete: "off" } %>
-  <%= f.input(:image, as: :hidden, input_html: { class: "js-image-data" }) unless photo.persisted? %>
+  <%= f.input(:image, as: :hidden, input_html: { value: f.object.cached_image_data, class: "js-image-data" }) unless photo.persisted? %>
   <%= f.input :sort_order, as: :hidden, input_html: { class: "js-uploader__sort-field" } %>
   <%= f.input :_destroy, as: :hidden, input_html: { class: "js-uploader__destroy-field" } %>
 </li>


### PR DESCRIPTION
Fix the hidden field for uploaded files on validation errors when submitting a new project submission (hidden field was storing the "inspected" string for the uploader object, rather than the JSON information of the cached file).