### PR TITLE
Replace project display event handlers (actions menu, hide, comment) with Stimulus controllers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'sassc-rails', '~> 2.1'
 gem 'shrine', '~> 3'
 gem 'shrine-tus', '~> 2.1', require: false
 gem 'simple_form', '~> 5.1'
+gem 'stimulus-rails'
 gem 'sucker_punch', '~> 3.1'
 gem 'terser'
 gem 'textacular', '~> 5.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,8 @@ GEM
     sprockets-redirect (0.1.0)
       activesupport (>= 3.1.0)
       rack
+    stimulus-rails (1.1.1)
+      railties (>= 6.0.0)
     sucker_punch (3.1.0)
       concurrent-ruby (~> 1.0)
     terser (1.1.12)
@@ -471,6 +473,7 @@ DEPENDENCIES
   shrine-tus (~> 2.1)
   simple_form (~> 5.1)
   sprockets-redirect
+  stimulus-rails
   sucker_punch (~> 3.1)
   terser
   textacular (~> 5.5.1)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -8,6 +8,7 @@
 // importmap links
 //= link application.js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../../javascript .js
 
 // To render React components in production, precompile the server rendering manifest
 //= link server_rendering.js

--- a/app/assets/javascripts/projects.js.coffee
+++ b/app/assets/javascripts/projects.js.coffee
@@ -65,18 +65,6 @@ populate_funded_description = ->
 
 $('#project_funded_on').blur(populate_funded_description)
 
-showHideOptions = ->
-  $("#project#{$(this).data("projectId")} .filtering").addClass("show-form")
-  false
-
-$(".hideFormLink").click(showHideOptions)
-
-showCommentForm = ->
-  $(this).parent().addClass("expanded")
-  false
-
-$(".comment-form-expand").click(showCommentForm)
-
 $(".comment-form")
   .on("ajax:success", (event, data, status, xhr) ->
     CommentStore.setComments(data.comments, data.project_id)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,1 +1,2 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "controllers"

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello World!"
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,11 @@
+// Import and register all your controllers from the importmap under controllers/*
+
+import { application } from "controllers/application"
+
+// Eager load all controllers defined in the import map under controllers/**/*_controller
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)
+
+// Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
+// import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
+// lazyLoadControllersFrom("controllers", application)

--- a/app/javascript/controllers/js_controller.js
+++ b/app/javascript/controllers/js_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+// https://gist.github.com/adrienpoly/862846f5882796fdeb4fc85b260b3c5a
+export default class extends Controller {
+  static values = { loaded: false }
+
+  connect() {
+    this.loadedValue = true
+  }
+}

--- a/app/javascript/controllers/revealer_controller.js
+++ b/app/javascript/controllers/revealer_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    expandedClass: 'expanded',
+  }
+
+  reveal(event) {
+    this.element.classList.add(this.expandedClassValue)
+    event.preventDefault()
+  }
+}

--- a/app/javascript/controllers/toggler_controller.js
+++ b/app/javascript/controllers/toggler_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "toggleable" ]
+
+  toggle(event) {
+    $(this.toggleableTarget).toggle('blind')
+    $(event.target).blur()
+    event.preventDefault()
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
   <%= content_for :head %>
   <%= javascript_importmap_tags %>
 </head>
-<body class="<%= body_class %>">
+<body class="<%= body_class %>" data-controller="js">
   <div id="site-container" class="flexbox vertical stretch">
     <%= render 'shared/navigation' %>
     <div class="flexbox vertical center">

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -5,7 +5,7 @@
     <%= render "projects/project_hidden", project: project %>
   <% end %>
 
-  <section class="filtering">
+  <section class="filtering" data-controller="revealer" data-revealer-expanded-class-value="show-form">
     <% if project.hidden? %>
       <div>
         <%= t(".hidden-details", username: project.hidden_by_user.name, hidden_at: l(project.hidden_at.to_date), reason: project.hidden_reason) %>
@@ -13,7 +13,7 @@
           (<%= link_to t(".view-application"), chapter_project_path(project.chapter, project), :class => "title" %>)
         <% end %>
       </div>
-      <%# only display the unhide button if we're reviewing the whole project %>
+      <%# only display the unhide button if we are reviewing the whole project %>
       <% if @display_project_even_if_hidden %>
         <div class="unhiding-form">
           <%= button_to t(".unhide"), unhide_project_path(id: project.id), method: :put, class: "hide-action" %>
@@ -25,7 +25,7 @@
     <% else %>
       <div class="consider-hiding">
         <%= t(".consider-hiding") %>
-        <%= link_to t(".hide"), "#", data: {"project-id" => project.id}, class: "hideFormLink" %>
+        <%= link_to t(".hide"), "#", data: { project_id: project.id, action: "click->revealer#reveal" }, class: "hideFormLink" %>
       </div>
       <div class="hiding-form">
         <%= form_tag hide_project_path(project), method: :put, class: "hide-form" do %>

--- a/app/views/projects/_project_actions_js.html.erb
+++ b/app/views/projects/_project_actions_js.html.erb
@@ -1,13 +1,5 @@
 <% content_for :javascript do %>
   <% javascript_tag do %>
-    $(window).load(function() {
-      $('.project-actions-toggle').on('click', function(event) {
-        event.preventDefault();
-        $(this).parents('header').find('.project-actions').toggle('blind');
-        $(this).blur();
-      });
-    });
-
     const projectNavigator = new ProjectNavigator();
 
     document.addEventListener("keydown", (event) => {

--- a/app/views/projects/_project_details.html.erb
+++ b/app/views/projects/_project_details.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header data-controller="toggler">
   <div class="title">
     <%= link_to project.title, chapter_project_path(project.chapter, project), :class => "title" %>
 
@@ -11,7 +11,7 @@
     <% end %>
 
     <% if display_project_actions?(current_user, project) %>
-      <%= link_to '<i class="icon-gear"></i>'.html_safe, "#", :class => "project-actions-toggle" %>
+      <%= link_to '<i class="icon-gear"></i>'.html_safe, "#", class: "project-actions-toggle", data: { action: "click->toggler#toggle" } %>
     <% end %>
     </div>
 
@@ -25,7 +25,7 @@
   <section class="meta-data">
     <%= project.created_at %> (<%= project.chapter.display_name %>)
 
-    <section class="project-actions">
+    <section class="project-actions" data-toggler-target="toggleable">
       <ul class="icons-ul">
         <% if current_user.can_mark_winner?(project) %>
           <li class="non-winner-action">
@@ -138,8 +138,8 @@
     <div class="project__comments-inner">
       <%= react_component("CommentList", { projectId: project.id, currentUserId: current_user.id, deleteBasePath: project_comments_path(project), initialComments: @initial_comments, deleteConfirmationText: I18n.t(".confirm-delete-comment", scope: "projects.project"), deleteIconText: I18n.t(".delete-comment", scope: "projects.project"), deletePermission: current_user.can_edit_project?(project) }, { prerender: @initial_comments.present? }) %>
 
-      <div class="comment-form-wrapper">
-        <%= link_to I18n.t(".add-comment", scope: "projects.project"), "javascript:void(0)", class: "comment-form-expand" %>
+      <div class="comment-form-wrapper" data-controller="revealer">
+        <%= link_to I18n.t(".add-comment", scope: "projects.project"), "#", class: "comment-form-expand", data: { action: "click->revealer#reveal" } %>
 
         <%= simple_form_for [project, Comment.new], method: :post, remote: true, html: { class: "comment-form" } do |f| %>
           <%= f.input :viewable_by, collection: Comment::VIEWABLE_OPTIONS, include_blank: false, wrapper_html: { class: "comment-form__viewable-by" }, label_html: { class: "comment-form__label--inline" } %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,3 +1,6 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application", preload: true
+pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
+pin_all_from "app/javascript/controllers", under: "controllers"

--- a/spec/features/step_definitions/project_steps.rb
+++ b/spec/features/step_definitions/project_steps.rb
@@ -258,6 +258,7 @@ step 'I should be on the project page for that project' do
 end
 
 step 'I expand the project menu' do
+  ensure_js_is_ready
   project = page.find("article.project", match: :first)
   project.find(".project-actions-toggle").click
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,3 +31,7 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+def ensure_js_is_ready
+  expect(page).to have_css('[data-js-loaded-value="true"]')
+end


### PR DESCRIPTION
This doesn't do much now but it will help in the future when we want to interact with these items more with turbo and don't want to keep having to rebind event handlers.