### PR TITLE
Add the CANONICAL_HOST setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ In order to prevent that redirect for other installations (such as staging envir
 SUBDOMAIN=staging
 ```
 
+Alternately, you can set the `CANONICAL_HOST` environment variable which will force all non-chapter subdomain redirects to be redirected to the canonical hostname. This is necessary to ensure that the main site is not served up by stray hostnames due to wildcard DNS. i.e. www.m.awesomefoundation.org should redirect to the canonical www.awesomefoundation.org host for SEO and overall confusion reasons.
+
+```shell
+CANONICAL_HOST=www.awesomefoundation.org
+```
+
 
 Secret Token
 ------------

--- a/app/controllers/subdomains_controller.rb
+++ b/app/controllers/subdomains_controller.rb
@@ -3,18 +3,30 @@ class SubdomainsController < ApplicationController
 
   def chapter
     if @chapter
-      redirect_to(chapter_url(@chapter.slug, :subdomain => @subdomain)) and return
+      redirect_to(chapter_url(@chapter.slug, url_parts))
 
     else
-      redirect_to(root_url(:subdomain => @subdomain)) and return
+      redirect_to(root_url(url_parts))
     end
   end
 
   def apply
-    redirect_to(new_submission_url(:subdomain => @subdomain, :chapter => @chapter)) and return
+    redirect_to(new_submission_url({ chapter: @chapter }.merge(url_parts)))
+  end
+
+  def canonical
+    redirect_to({ locale: nil }.merge(url_parts), status: :moved_permanently)
   end
 
   protected
+
+  def url_parts
+    if ENV['CANONICAL_HOST'].present?
+      { host: ENV['CANONICAL_HOST'] }
+    else
+      { subdomain: @subdomain }
+    end
+  end
 
   def find_chapter
     subdomains = request.subdomains

--- a/app/extras/domain_constraint.rb
+++ b/app/extras/domain_constraint.rb
@@ -1,0 +1,5 @@
+class DomainConstraint
+  def self.matches?(request)
+    ENV['CANONICAL_HOST'].present? && request.host != ENV['CANONICAL_HOST']
+  end
+end

--- a/app/extras/subdomain_constraint.rb
+++ b/app/extras/subdomain_constraint.rb
@@ -1,5 +1,9 @@
 class SubdomainConstraint
   def self.matches?(request)
+    if ENV['CANONICAL_HOST'].present?
+      return false if request.host == ENV['CANONICAL_HOST']
+    end
+
     case request.subdomains.first
     when 'www', '', nil, ENV['SUBDOMAIN']
       false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: "#{ENV['SUBDOMAIN'] || 'www'}.awesomefoundation.org" }
+  config.action_mailer.default_url_options = { host: ENV['CANONICAL_HOST'].presence || "#{ENV['SUBDOMAIN'] || 'www'}.awesomefoundation.org" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/rack-cors.rb
+++ b/config/initializers/rack-cors.rb
@@ -4,8 +4,13 @@
 # https://devcenter.heroku.com/articles/using-amazon-cloudfront-cdn#cors
 Rails.configuration.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "https://#{ ENV['SUBDOMAIN'] || "www" }.awesomefoundation.org",
-             "http://#{ ENV['SUBDOMAIN'] || "www" }.awesomefoundation.org"
+    if ENV['CANONICAL_HOST'].present?
+      origins "https://#{ENV['CANONICAL_HOST']}",
+              "http://#{ENV['CANONICAL_HOST']}"
+    else
+      origins "https://#{ ENV['SUBDOMAIN'] || "www" }.awesomefoundation.org",
+              "http://#{ ENV['SUBDOMAIN'] || "www" }.awesomefoundation.org"
+    end
 
     resource '/assets/*', headers: :any, methods: [:get, :post, :options]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
     get "/"      => "subdomains#chapter"
   end
 
+  constraints(DomainConstraint) do
+    get "*url" => "subdomains#canonical"
+    get "/"    => "subdomains#canonical"
+  end
+
   get "/blog/contact/" => redirect("/en/contact")
   get "/blog/about/"   => redirect("/en/about_us")
   get "/blog"          => redirect("http://blog.awesomefoundation.org")

--- a/spec/controllers/subdomains_controller_spec.rb
+++ b/spec/controllers/subdomains_controller_spec.rb
@@ -42,4 +42,31 @@ describe SubdomainsController do
       it { is_expected.to redirect_to("http://www.test.host/#{I18n.default_locale}") }
     end
   end
+
+  context "with canonical host" do
+    around(:each) do |example|
+      ENV['CANONICAL_HOST'] = "www.test.host"
+      example.run
+      ENV['CANONICAL_HOST'] = nil
+    end
+
+    before do
+      @request.host = "www.dummy.test.host"
+    end
+
+    it { is_expected.to route(:get, "http://www.dummy.test.host").to(controller: "subdomains", action: "canonical") }
+    it { is_expected.to route(:get, "http://www.dummy.test.host/en/projects").to(controller: "subdomains", action: "canonical", url: "en/projects") }
+    it { is_expected.to route(:get, "http://nyc.test.host").to(controller: "subdomains", action: "chapter") }
+
+    it "should redirect homepage without locale" do
+      get :canonical
+
+      expect(response).to redirect_to("http://www.test.host/")
+    end
+
+    it "should redirect project page with locale" do
+      get :canonical, params: { url: "pt/projects" }
+      expect(response).to redirect_to("http://www.test.host/pt/projects")
+    end
+  end
 end


### PR DESCRIPTION
Ensure that requests to stray wildcard hosts like www.m.awesomefoundation.org are redirected to the canonical host for SEO and overall user confusion reasons.