### PR TITLE
Fix linking error in i18n footer links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,4 +35,8 @@ module ApplicationHelper
 
     tag :meta, options.merge(:content => content_for?(content_tag) ? content_for(content_tag) : content)
   end
+
+  def current_params_with_locale(locale)
+    params.reject { |p| %w(params).include?(p) }.permit!.merge(locale: locale, only_path: true)
+  end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -14,12 +14,12 @@
   </p>
 
   <p>
-    <%= link_to "Български", params.permit!.merge(locale: "bg", only_path: true) %>
-    <%= link_to "English", params.permit!.merge(locale: "en", only_path: true) %>
-    <%= link_to "Español", params.permit!.merge(locale: "es", only_path: true) %>
-    <%= link_to "Français", params.permit!.merge(locale: "fr", only_path: true) %>
-    <%= link_to "ՀԱՅԵՐԵՆ", params.permit!.merge(locale: "hy", only_path: true) %>
-    <%= link_to "Português", params.permit!.merge(locale: "pt", only_path: true) %>
-    <%= link_to "Русский", params.permit!.merge(locale: "ru", only_path: true) %>
+    <%= link_to "Български", current_params_with_locale("bg") %>
+    <%= link_to "English", current_params_with_locale("en") %>
+    <%= link_to "Español", current_params_with_locale("es") %>
+    <%= link_to "Français", current_params_with_locale("fr") %>
+    <%= link_to "ՀԱՅԵՐԵՆ", current_params_with_locale("hy") %>
+    <%= link_to "Português", current_params_with_locale("pt") %>
+    <%= link_to "Русский", current_params_with_locale("ru") %>
   </p>
 </footer>


### PR DESCRIPTION
When being passed a param with the name "params" the footer i18n language links were failing with the message:

ActionView::Template::Error no implicit conversion of String into Hash

This is presumably someone just stuffing params into our query strings but bad data shouldn't cause the page to crash, so let's just strip out the offending parameter for now.

https://app.rollbar.com/a/awesomefoundation/fix/item/awesomefoundation/353