### PR TITLE
Update finalists page to default to hiding funded and hidden projects

### DIFF
--- a/app/assets/stylesheets/_finalists.scss
+++ b/app/assets/stylesheets/_finalists.scss
@@ -16,7 +16,7 @@ section.applications {
     font-size: 0.8em;
     
     tr {
-      td {
+      td, th {
         &:first-child {
           width: 75%;
         }
@@ -28,7 +28,11 @@ section.applications {
         &:nth-child(3) {
           width: 10%;
         }
-        
+
+        &.vote-count {
+            text-align: center;
+        }
+
         a {
           font-weight: bold;
           color: rgb(55,55,55);
@@ -41,7 +45,13 @@ section.applications {
         .winner {
           color: $pink;
         }
+        .sorted:after {
+            content: ' \21c5';
+        }
 
+      }
+      th {
+          white-space: nowrap;
       }
     }
   }

--- a/app/controllers/finalists_controller.rb
+++ b/app/controllers/finalists_controller.rb
@@ -16,6 +16,14 @@ class FinalistsController < ApplicationController
     unless params[:past_trustees].present?
       @projects = @projects.with_votes_by_members_of_chapter(current_chapter)
     end
+
+    unless params[:hidden].present?
+      @projects = @projects.where(hidden_at: nil)
+    end
+
+    unless params[:funded].present?
+      @projects = @projects.where(funded_on: nil)
+    end
   end
 
   private

--- a/app/controllers/finalists_controller.rb
+++ b/app/controllers/finalists_controller.rb
@@ -6,12 +6,14 @@ class FinalistsController < ApplicationController
   include ApplicationHelper
 
   def index
+    @sort = %w(title date).include?(params[:sort]) ? params[:sort] : "votes"
+
     @start_date, @end_date = extract_timeframe
     @projects = Project.
                   includes(:chapter).
                   with_votes_for_chapter(current_chapter).
                   during_timeframe(@start_date, @end_date).
-                  by_vote_count
+                  by_vote_count(sort: @sort)
 
     unless params[:past_trustees].present?
       @projects = @projects.with_votes_by_members_of_chapter(current_chapter)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -82,11 +82,17 @@ class Project < ApplicationRecord
     )
   end
 
-  def self.by_vote_count
-    select("projects.chapter_id, projects.id, projects.title, projects.funded_on, COUNT(votes.project_id) as vote_count").
+  def self.by_vote_count(sort: nil)
+    order = case sort
+            when "date" then "projects.created_at DESC, vote_count DESC"
+            when "title" then "projects.title ASC, vote_count DESC"
+            else "vote_count DESC, projects.created_at ASC"
+            end
+
+    select("projects.chapter_id, projects.id, projects.title, projects.funded_on, COUNT(votes.project_id) as vote_count, projects.created_at").
       group("projects.id, projects.title, votes.project_id").
       joins(:users).
-      order("vote_count DESC, projects.created_at ASC")
+      order(order)
   end
 
   def self.winners

--- a/app/views/finalists/index.html.erb
+++ b/app/views/finalists/index.html.erb
@@ -52,9 +52,9 @@
 
   <table>
     <tr class="headers">
-      <th><%= t ".table.title" %></th>
-      <th><%= t ".table.id " %></th>
-      <th><%= t ".table.votes" %></th>
+      <th><%= link_to t(".table.title"), request.params.merge(sort: "title"), class: ("sorted" if @sort == "title") %></th>
+      <th><%= link_to t(".table.date"),  request.params.merge(sort: "date"),  class: ("sorted" if @sort == "date") %></th>
+      <th><%= link_to t(".table.votes"), request.params.merge(sort: "votes"), class: ("sorted" if @sort == "votes") %></th>
     </tr>
     <% @projects.each do |project| %>
       <tr class="finalist" data-count="<%= project.vote_count %>" data-id="<%= project.id %>">
@@ -65,7 +65,7 @@
             - <em><%= project.chapter.display_name %></em>
           <% end %>
         </td>
-        <td><%= project.id %></td>
+        <td><%= project.created_at.strftime("%Y-%m-%d") %></td>
         <td class="vote-count"><%= project.vote_count %></td>
       </tr>
     <% end %>

--- a/app/views/finalists/index.html.erb
+++ b/app/views/finalists/index.html.erb
@@ -36,6 +36,16 @@
         <%= label_tag "past_trustees", t(".past-trustees-filter") %>
       </div>
 
+      <div class="input toggle">
+        <%= check_box_tag "funded", nil, params[:funded].present? %>
+        <%= label_tag "funded", t(".funded-filter") %>
+      </div>
+
+      <div class="input toggle">
+        <%= check_box_tag "hidden", nil, params[:hidden].present? %>
+        <%= label_tag "hidden", t(".hidden-filter") %>
+      </div>
+
       <input name="" type="submit" value="<%= t(".filter-button") %>">
     </form>
   </section>

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -114,6 +114,7 @@ bg:
         title: Заглавие
         id: ID
         votes: Гласове
+        date: дата
   funded_projects:
     show:
       edit: Редактирай проект

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -108,6 +108,8 @@ bg:
       filter-button: Филтър
       start-date: стартова дата
       end-date: крайна дата
+      hidden-filter: Скрит
+      funded-filter: победители
       table:
         title: Заглавие
         id: ID

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,7 +111,9 @@ en:
       filter-button: Filter
       start-date: start date
       end-date: end date
-      past-trustees-filter: Include votes from past trustees
+      past-trustees-filter: Votes from past trustees
+      hidden-filter: Hidden
+      funded-filter: Funded
       table:
         title: Title
         id: ID

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,7 @@ en:
         title: Title
         id: ID
         votes: Votes
+        date: Date
   funded_projects:
     index:
       all_chapters: All Chapters

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -109,6 +109,8 @@ es:
       filter-button: Filtro
       start-date: fecha de inicio
       end-date: fecha final
+      hidden-filter: Escondido
+      funded-filter: Fondos
       table:
         title: Título
         id: Identificación

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -115,6 +115,7 @@ es:
         title: Título
         id: Identificación
         votes: Votos
+        date: Fecha
   funded_projects:
     show:
       view-photos: "Ver fotos"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -108,6 +108,8 @@ fr:
       filter-button: Filtrer
       start-date: Date de début
       end-date: Date de fin
+      hidden-filter: Masqué
+      funded-filter: Financé
       table:
         title: Titre
         id: ID

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -114,6 +114,7 @@ fr:
         title: Titre
         id: ID
         votes: Votes
+        date: Date
   funded_projects:
     show:
       edit: Editer le Projet

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -114,6 +114,7 @@
         title: Անվանում
         id: ID
         votes: Քվեներ
+        date: օր
   funded_projects:
     show:
       edit: Խմբագրել նախագիծ

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -108,6 +108,8 @@
       filter-button: Զտել
       start-date: Մեկնարկի օր
       end-date: Ավարտի օր
+      hidden-filter: Թաքցված
+      funded-filter: հաղթողներին
       table:
         title: Անվանում
         id: ID

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -114,6 +114,7 @@ pt:
         title: Título
         id: ID
         votes: Votos
+        date: Data
   funded_projects:
     show:
       edit: Editar Projeto

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -108,6 +108,8 @@ pt:
       filter-button: Filtro
       start-date: data inicial
       end-date: data final
+      hidden-filter: Escondido
+      funded-filter: Financiado
       table:
         title: Título
         id: ID

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -106,6 +106,7 @@ ru:
         title: название
         id: ID-номер
         votes: голос(ов)
+        date: дата
   funded_projects:
     show:
       edit: Редактировать проект

--- a/spec/controllers/finalists_controller_spec.rb
+++ b/spec/controllers/finalists_controller_spec.rb
@@ -5,6 +5,8 @@ describe FinalistsController do
     let(:chapter) { FactoryGirl.create(:chapter) }
     let(:project1) { FactoryGirl.create(:project, chapter: chapter) }
     let(:project2) { FactoryGirl.create(:project, chapter: chapter) }
+    let(:funded_project) { FactoryGirl.create(:winning_project, chapter: chapter) }
+    let(:hidden_project) { FactoryGirl.create(:hidden_project, chapter: chapter) }
     let(:trustee_role) { FactoryGirl.create(:role, :trustee, chapter: chapter) }
     let(:past_trustee_role) { FactoryGirl.create(:role, :trustee, chapter: chapter) }
     let!(:past_trustee) { past_trustee_role.user }
@@ -12,6 +14,8 @@ describe FinalistsController do
     before do
       Vote.create!(project: project1, user: trustee_role.user, chapter: chapter)
       Vote.create!(project: project2, user: past_trustee, chapter: chapter)
+      Vote.create!(project: funded_project, user: trustee_role.user, chapter: chapter)
+      Vote.create!(project: hidden_project, user: trustee_role.user, chapter: chapter)
 
       past_trustee_role.destroy
 
@@ -20,11 +24,13 @@ describe FinalistsController do
 
     render_views
 
-    it "only shows projects voted on by current trustees by default" do
+    it "only shows projects voted on by current trustees, unfunded, unhidden by default" do
       get :index, params: { chapter_id: chapter }
 
       expect(response.body).to have_selector("tr.finalist[data-id='#{project1.id}']")
       expect(response.body).to_not have_selector("tr.finalist[data-id='#{project2.id}']")
+      expect(response.body).to_not have_selector("tr.finalist[data-id='#{hidden_project.id}']")
+      expect(response.body).to_not have_selector("tr.finalist[data-id='#{funded_project.id}']")
     end
 
     it "shows projects voted on by all trustees when the past_trustees param is set" do
@@ -32,6 +38,18 @@ describe FinalistsController do
 
       expect(response.body).to have_selector("tr.finalist[data-id='#{project1.id}']")
       expect(response.body).to have_selector("tr.finalist[data-id='#{project2.id}']")
+    end
+
+    it "shows hidden projects when hidden filter is set" do
+      get :index, params: { chapter_id: chapter, hidden: "on" }
+
+      expect(response.body).to have_selector("tr.finalist[data-id='#{hidden_project.id}']")
+    end
+
+    it "shows funded projects when funded filter is set" do
+      get :index, params: { chapter_id: chapter, funded: "on" }
+
+      expect(response.body).to have_selector("tr.finalist[data-id='#{funded_project.id}']")
     end
   end
 end

--- a/spec/controllers/finalists_controller_spec.rb
+++ b/spec/controllers/finalists_controller_spec.rb
@@ -10,6 +10,7 @@ describe FinalistsController do
     let(:trustee_role) { FactoryGirl.create(:role, :trustee, chapter: chapter) }
     let(:past_trustee_role) { FactoryGirl.create(:role, :trustee, chapter: chapter) }
     let!(:past_trustee) { past_trustee_role.user }
+    let(:projects) { [project1, project2, funded_project, hidden_project] }
 
     before do
       Vote.create!(project: project1, user: trustee_role.user, chapter: chapter)
@@ -50,6 +51,20 @@ describe FinalistsController do
       get :index, params: { chapter_id: chapter, funded: "on" }
 
       expect(response.body).to have_selector("tr.finalist[data-id='#{funded_project.id}']")
+    end
+
+    context "sorting" do
+      it "sorts by title" do
+        get :index, params: { chapter_id: chapter, past_trustees: "on", funded: "on", "hidden": "on", sort: "title" }
+
+        expect(controller.view_assigns['projects'].collect { |p| p.id }).to eq(projects.sort { |a, b| a.title <=> b.title }.collect { |p| p.id })
+      end
+
+      it "sorts by creation date" do
+        get :index, params: { chapter_id: chapter, past_trustees: "on", funded: "on", "hidden": "on", sort: "date" }
+
+        expect(controller.view_assigns['projects'].collect { |p| p.id }).to eq(projects.sort { |a, b| b.created_at <=> a.created_at }.collect { |p| p.id })
+      end
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -72,6 +72,11 @@ FactoryGirl.define do
     factory :winning_project do
       sequence(:funded_on) { |n| (3000-n.to_i).days.ago }
     end
+
+    factory :hidden_project do
+      hidden_reason "Hidden"
+      hidden_at { rand(30).days.ago }
+    end
   end
 
   factory :vote do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -57,7 +57,7 @@ FactoryGirl.define do
 
   factory :project do
     name "Joe Schmoe"
-    title
+    title { Faker::Lorem.sentence(word_count: 5) }
     email
     url "http://something.com"
     about_project "I am awesome."

--- a/spec/views/finalists_views_spec.rb
+++ b/spec/views/finalists_views_spec.rb
@@ -5,6 +5,10 @@ describe 'finalists/index' do
   let!(:project1) { FactoryGirl.create(:project, chapter: user.chapters.first) }
   let!(:project2) { FactoryGirl.create(:project) }
 
+  before(:each) do
+    controller.request.params[:chapter_id] = project1.chapter
+  end
+
   describe 'when a project from another chapter has votes from our trustees' do
     it 'displays the name of the other chapter next to that project title' do
       Vote.create(user: user, project: project1, chapter: project1.chapter)


### PR DESCRIPTION
The finalists page is intended to be used by trustees to find projects to fund in a given month. While some chapters review applications that come in month by month, others will review the entire pool of applications ever month. For these chapters, seeing all past funded projects in the finalists list is distracting, and counter to the purpose of the finalists page in the first place.

This PR changes the default view of the finalists page to only include unfunded and unhidden projects (again, if a project was hidden from review, it was probably for a reason). We also include checkboxes to be able to re-include these filtered projects if desired.

Also change the "id" column to the application date and add column sorting.



![Screen Shot 2023-05-06 at 2 46 44 AM](https://user-images.githubusercontent.com/2909/236607972-17912c46-cab3-4b29-8fda-bd0584dda702.png)
