### PR TITLE
BUGFIX: Fix comment 'human time' formatting

### DIFF
--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -5,4 +5,4 @@
 #   Time::DATE_FORMATS[format_name] = format_string
 # end
 
-Time::DATE_FORMATS[:long_with_zone] = "%B %d, %Y %H:%m %Z"
+Time::DATE_FORMATS[:long_with_zone] = "%B %d, %Y %H:%M %Z"


### PR DESCRIPTION
Sigh, we were using `%m` (month of year) instead of `%M` (minute of hour).