### PR TITLE
Fix user csv quoting

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
         @users = @users.paginate(page: params[:page], per_page: 250)
       end
       format.csv do
+        headers["Content-Disposition"] = "attachment; filename=#{current_chapter.slug}_users.csv" if current_chapter.present?
       end
     end
   end

--- a/app/views/users/index.csv.erb
+++ b/app/views/users/index.csv.erb
@@ -1,4 +1,4 @@
 <%= CSV.generate_line %w[id first_name last_name email url chapter_name role created_at updated_at] -%>
 <%- @users.each do |user| -%>
-  <%= CSV.generate_line [user.id, user.first_name, user.last_name, user.email, user.url, user.chapter_name, user.role_name, user.created_at.to_s(:iso8601), user.updated_at.to_s(:iso8601)] -%>
+  <%= CSV.generate_line([user.id, user.first_name, user.last_name, user.email, user.url, user.chapter_name, user.role_name, user.created_at.to_s(:iso8601), user.updated_at.to_s(:iso8601)]).html_safe -%>
 <%- end -%>


### PR DESCRIPTION
* Users CSV no longer escapes quotes
* Users CSV includes chapter slug when downloading users CSV file for a chapter