### PR TITLE
BUGFIX: Force comments to load on initial render

### DIFF
--- a/app/assets/javascripts/components/comment_list.js.jsx
+++ b/app/assets/javascripts/components/comment_list.js.jsx
@@ -16,6 +16,11 @@ var CommentList = createReactClass({
     }
   },
 
+  componentDidMount: function() {
+    // Force an update after mounting to ensure we have the latest data
+    this.updateComments();
+  },
+
   componentWillUnmount: function() {
     CommentStore.unsubscribe(this.updateComments);
   },

--- a/app/assets/javascripts/server_rendering.js
+++ b/app/assets/javascripts/server_rendering.js
@@ -4,4 +4,4 @@
 //
 // By default, this file is loaded for server-side rendering.
 // It should require your components and any dependencies.
-//=require ./awesome_react
+//= require ./awesome_react

--- a/app/views/projects/_comments_js.html.erb
+++ b/app/views/projects/_comments_js.html.erb
@@ -1,6 +1,6 @@
 <% content_for :javascript do %>
   <% javascript_tag do %>
-    $(window).load(function() {
+    window.addEventListener("load", function () {
       CommentStore.setComments(<%= comments.to_json.html_safe %>);
     });
   <% end %>


### PR DESCRIPTION
1. After the component is mounted to the DOM, componentDidMount will be called
2. The updateComments method will be executed, which calls setState with the latest comments from the store
3. This will force a re-render with the most up-to-date data