### PR TITLE
Add project moderation system for spam review

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rake'
 gem 'bootsnap','>= 1.1.0', require: false
 
 gem 'addressable'
+gem 'anyway_config'
 gem 'aws-sdk-s3'
 gem 'bourbon', '~> 4.0.2'
 gem 'clearance', '~> 2.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    anyway_config (2.7.2)
+      ruby-next-core (~> 1.0)
     argon2 (2.3.2)
       ffi (~> 1.15)
       ffi-compiler (~> 1.0)
@@ -383,6 +385,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.2)
+    ruby-next-core (1.1.2)
     rubyzip (2.4.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -484,6 +487,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
+  anyway_config
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   bourbon (~> 4.0.2)

--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -41,7 +41,7 @@ body.home-index, body.chapters-show, body.chapters-index {
   }
 }
 
-body:not(.home-index):not(.chapters-show) {  
+body:not(.home-index):not(.chapters-show) {
   section.container {
     margin-top: 3em;
   }
@@ -72,4 +72,16 @@ table {
     padding: 10px 0px;
     width: 100%;
   }
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.block {
+  display: block;
+}
+
+.clear-both {
+  clear: both;
 }

--- a/app/assets/stylesheets/_projects-index.scss
+++ b/app/assets/stylesheets/_projects-index.scss
@@ -3,13 +3,13 @@ body.projects-index {
   section.container {
     @extend .clearfix;
   }
-  
+
   @media all and (max-width: $maximum-width) {
     section.container {
       margin-top: 0.5em !important;
     }
   }
-  
+
 }
 
 .application__image-wrapper {
@@ -29,6 +29,48 @@ body.projects-index {
   &:hover {
     opacity: 1;
   }
+}
+
+.application__moderation-actions {
+  float: right;
+  gap: 10px;
+}
+
+.application__moderation-notice {
+  row-gap: .5em;
+}
+
+.application__moderation-status {
+  padding: .3em .3em .3em .5em;
+  border-radius: 4px;
+  font-size: .8em;
+}
+
+.application__moderation-status--alert {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.application__moderation-status--success {
+  background: #d4edda;
+  color: #155724;
+}
+
+.application__moderation-button {
+  @include button(rgb(230,230,230));
+  margin: 0px;
+  width: auto;
+  font-size: .8em;
+  display: inline-block;
+  font-weight: normal;
+  text-decoration: none !important;
+  color: $base-font-color !important;
+}
+
+.application__moderation-signals {
+  margin-right: 8px;
+  color: #666;
+  cursor: pointer;
 }
 
 .admin-panel {
@@ -142,7 +184,7 @@ body.projects-index {
 .applications {
   float: left;
   max-width: grid-width(9);
-  
+
   /* Ensure 'Back to Chapter' link on admin view of project page is the correct font size */
   > p:nth-child(2) {
     font-size: 0.8em;
@@ -237,9 +279,9 @@ body.projects-index {
         z-index: 1;
         margin-top: -1px;
         margin-bottom: 0px;
-        
+
         &.bounded {
-          max-height: 428px;          
+          max-height: 428px;
         }
 
         li {

--- a/app/assets/stylesheets/_shared-header.scss
+++ b/app/assets/stylesheets/_shared-header.scss
@@ -97,11 +97,11 @@ header.main {
           float: left;
           clear: both;
           margin: 10px 0px;
-          
+
           &:first-child {
             margin-top: 14px;
           }
-          
+
           &:last-child {
             margin-bottom: 14px;
           }
@@ -206,6 +206,13 @@ body {
 
   &.projects-index,
   &.finalists-index {
+    a.dashboard {
+      @extend .active-link;
+    }
+  }
+
+
+  &.moderations-index {
     a.dashboard {
       @extend .active-link;
     }

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -1,0 +1,62 @@
+class ModerationsController < ApplicationController
+  before_action :require_login
+  before_action :find_chapter, only: [:index]
+  before_action :find_project_and_chapter, only: [:confirm_spam, :confirm_legit, :undo]
+  before_action :ensure_user_can_moderate
+
+  def index
+    @projects = projects_scope(all: params[:filter] == "all")
+    @moderation_count = @projects.count
+
+    @comments = Comment.where(project: @projects).includes(:user, :project).viewable_by(user: current_user, chapter: @chapter).by_date
+    @projects = @projects.includes(:users, :project_moderation).preload(:photos, :real_photos).order(created_at: :desc).page(params[:page])
+  end
+
+  def confirm_spam
+    @project.project_moderation&.mark_confirmed_spam!(current_user)
+    render partial: "projects/moderation", locals: {project: @project}
+  end
+
+  def confirm_legit
+    @project.project_moderation&.mark_confirmed_legit!(current_user)
+    render partial: "projects/moderation", locals: {project: @project}
+  end
+
+  def undo
+    if @project.project_moderation
+      @project.project_moderation.update!(
+        status: :suspected,
+        reviewed_by: nil,
+        reviewed_at: nil
+      )
+    end
+    render partial: "projects/moderation", locals: {project: @project}
+  end
+
+  private
+
+  def projects_scope(all: false)
+    if @chapter
+      all ? @chapter.projects.joins(:project_moderation) : @chapter.projects_pending_moderation
+    elsif current_user.admin?
+      all ? Project.joins(:project_moderation) : Project.joins(:project_moderation).merge(ProjectModeration.pending)
+    else
+      Project.none
+    end
+  end
+
+  def find_chapter
+    @chapter = Chapter.friendly.find(params[:chapter_id]) if params[:chapter_id]
+  end
+
+  def ensure_user_can_moderate
+    return if current_user.can_moderate_for?(@chapter)
+
+    render_404
+  end
+
+  def find_project_and_chapter
+    @project = Project.find(params[:project_id])
+    @chapter = @project.chapter
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,6 +16,9 @@ class ProjectsController < ApplicationController
 
     project_filter = ProjectFilter.new(@chapter.projects).during(@start_date, @end_date)
 
+    # Only display projects that do not require human review
+    project_filter.not_pending_moderation
+
     if params[:short_list]
       project_filter.shortlisted_by(current_user)
     end
@@ -29,6 +32,9 @@ class ProjectsController < ApplicationController
     unless @q.blank?
       project_filter.search(@q)
     end
+
+    # Count projects under moderation for the notification box
+    @moderation_count = @chapter.projects_pending_moderation.count
 
     respond_to do |format|
       format.html do

--- a/app/extras/project_filter.rb
+++ b/app/extras/project_filter.rb
@@ -29,6 +29,16 @@ class ProjectFilter
     self
   end
 
+  def not_pending_moderation
+    @projects = @projects.left_joins(:project_moderation).where(project_moderations: {id: nil}).or(@projects.merge(ProjectModeration.approved))
+    self
+  end
+
+  def pending_moderation
+    @projects = @projects.joins(:project_moderation).merge(ProjectModeration.pending)
+    self
+  end
+
   def result
     @projects
   end

--- a/app/extras/spam_classifier.rb
+++ b/app/extras/spam_classifier.rb
@@ -1,0 +1,134 @@
+class SpamClassifier
+  attr_accessor :score, :signals
+
+  def initialize(project)
+    @project = project
+    @metadata = project&.metadata || {}
+    @score = 0
+    @signals = []
+    @config = SpamConfig.new
+  end
+
+  def analyze!
+    # Check for missing metadata (bot indicator)
+    if all_js_fields_missing?
+      self.signals << "missing_js_metadata"
+      self.score += @config.weight_missing_js_metadata
+    end
+
+    # Very short time on page (less than 10 seconds)
+    if @metadata["time_on_page_ms"].present? && @metadata["time_on_page_ms"].to_i < @config.time_on_page_threshold_ms
+      self.signals << "short_time_on_page"
+      self.score += @config.weight_short_time_on_page
+    end
+
+    # No referrer (direct access, often bots)
+    if @metadata["referrer"].blank?
+      self.signals << "no_referrer"
+      self.score += @config.weight_no_referrer
+    end
+
+    # Suspicious user agents
+    if suspicious_user_agent?
+      self.signals << "suspicious_user_agent"
+      self.score += @config.weight_suspicious_user_agent
+    end
+
+    # Very few form interactions
+    if @metadata["form_interactions_count"].present? && @metadata["form_interactions_count"].to_i < @config.min_form_interactions
+      self.signals << "low_form_interactions"
+      self.score += @config.weight_low_form_interactions
+    end
+
+    # High paste to keystroke ratio (copy-paste behavior)
+    if high_paste_ratio?
+      self.signals << "high_paste_ratio"
+      self.score += @config.weight_high_paste_ratio
+    end
+
+    # Common bot screen resolutions
+    if bot_screen_resolution?
+      self.signals << "bot_screen_resolution"
+      self.score += @config.weight_bot_screen_resolution
+    end
+
+    # Gibberish fields detection
+    if gibberish_fields?
+      self.signals << "gibberish_fields"
+      self.score += @config.weight_gibberish_fields
+    end
+
+    analysis
+  end
+
+  def suspected_spam?
+    score >= @config.threshold
+  end
+
+  def analysis
+    {
+      score: score,
+      triggered: signals
+    }
+  end
+
+  private
+
+  def all_js_fields_missing?
+    js_fields = ["time_on_page_ms", "timezone", "screen_resolution", "form_interactions_count", "keystroke_count", "paste_count"]
+    js_fields.all? { |field| @metadata[field].blank? }
+  end
+
+  def suspicious_user_agent?
+    return false if @metadata["user_agent"].blank?
+
+    user_agent = @metadata["user_agent"].downcase
+
+    # Check for quoted user agents (clear bot indicator)
+    return true if user_agent.start_with?('"') && user_agent.end_with?('"')
+
+    suspicious_patterns = ["headlesschrome", "phantomjs", "selenium", "bot", "crawler", "spider"]
+    suspicious_patterns.any? { |pattern| user_agent.include?(pattern) }
+  end
+
+  def high_paste_ratio?
+    return false if @metadata["keystroke_count"].blank? || @metadata["paste_count"].blank?
+
+    keystrokes = @metadata["keystroke_count"].to_i
+    pastes = @metadata["paste_count"].to_i
+
+    return false if keystrokes == 0
+
+    paste_ratio = pastes.to_f / keystrokes
+    paste_ratio > @config.paste_ratio_threshold
+  end
+
+  def bot_screen_resolution?
+    return false if @metadata["screen_resolution"].blank?
+
+    resolution = @metadata["screen_resolution"]
+    # Common headless browser resolutions
+    bot_resolutions = ["1024x768", "1280x1024", "800x600"]
+    bot_resolutions.include?(resolution)
+  end
+
+  def gibberish_fields?
+    # Check these fields for gibberish (single words with no spaces)
+    fields_to_check = %w[name title about_me use_for_money about_project extra_answer_1 extra_answer_2 extra_answer_3]
+
+    gibberish_count = 0
+
+    fields_to_check.each do |field|
+      value = @project.send(field)
+      next if value.blank?
+
+      # Check if it's a single word (no spaces) and not empty
+      if value.strip.match?(/^\S+$/) && value.length > 1
+        gibberish_count += 1
+      end
+    end
+
+    # If more than threshold fields are single words, likely gibberish
+    gibberish_count > @config.gibberish_field_threshold
+  end
+end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -16,6 +16,7 @@ EOT
   has_many :roles
   has_many :users, :through => :roles
   has_many :projects
+  has_many :projects_pending_moderation, -> { joins(:project_moderation).merge(ProjectModeration.pending) }, class_name: "Project"
   has_many :winning_projects, -> { where.not(funded_on: nil).order(funded_on: :desc) }, class_name: "Project"
   has_many :invitations
 

--- a/app/models/project_moderation.rb
+++ b/app/models/project_moderation.rb
@@ -1,0 +1,34 @@
+class ProjectModeration < ApplicationRecord
+  belongs_to :project
+  belongs_to :reviewed_by, class_name: "User", optional: true
+
+  validates :project_id, uniqueness: true
+
+  enum :status, %w[unreviewed suspected confirmed_spam confirmed_legit].index_by(&:itself)
+  enum :moderation_type, %w[spam missing_metadata other].index_by(&:itself)
+
+  store_accessor :signals, :score, :triggered
+
+  scope :pending, -> { where(status: %w[unreviewed suspected]) }
+  scope :approved, -> { where(status: %w[confirmed_legit]) }
+
+  def mark_confirmed_spam!(user)
+    update!(
+      status: :confirmed_spam,
+      reviewed_by: user,
+      reviewed_at: Time.current
+    )
+  end
+
+  def mark_confirmed_legit!(user)
+    update!(
+      status: :confirmed_legit,
+      reviewed_by: user,
+      reviewed_at: Time.current
+    )
+  end
+
+  def reviewed?
+    reviewed_by.present?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,10 @@ class User < ApplicationRecord
     admin? || roles.can_view_finalists_for?(chapter)
   end
 
+  def can_moderate_for?(chapter)
+    admin? || chapter&.any_chapter? || (chapter && chapters.include?(chapter))
+  end
+
   def can_mark_winner?(project)
     admin? || project.in_any_chapter? || roles.can_mark_winner?(project)
   end

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -1,0 +1,33 @@
+<% provide :page_title, (@chapter ? t(".title", name: @chapter.display_name, count: @projects.count) : t(".moderation"))  %>
+<% provide :meta_viewport, "width=device-width, initial-scale=1, maximum-scale=1" %>
+
+<section class="admin-panel">
+  <%= render "shared/sidebar", chapter: @chapter %>
+</section>
+
+<section class="applications">
+  <% if @chapter.present? %>
+    <h1><%= t ".title", name: @chapter.display_name, count: @projects.count %></h1>
+  <% end %>
+
+  <div class="application__moderation-notice notice flexbox justify-space-between center wrap">
+    <strong>
+      <% if params[:filter] == "all" %>
+        <%= t(".viewing-all-moderated") %>
+        (<%= link_to t(".view-unmoderated-only"), {filter: nil} %>)
+      <% else %>
+        <%= t(".moderating-projects", count: @projects.count) %>
+        (<%= link_to t(".view-all"), {filter: "all"} %>)
+      <% end %>
+    </strong>
+
+    <%= link_to(t(".back-to-approved-projects"), chapter_projects_path(@chapter), class: "application__moderation-button") if @chapter.present? %>
+  </div>
+
+  <%= render @projects, moderation: true %>
+  <%= will_paginate(@projects) %>
+</section>
+
+<%= render "shared/lightbox" %>
+<%= render "projects/project_actions_js" %>
+<%= render "projects/comments_js", comments: @comments %>

--- a/app/views/projects/_moderation.html.erb
+++ b/app/views/projects/_moderation.html.erb
@@ -1,0 +1,24 @@
+<%= turbo_frame_tag "moderation_actions_#{project.id}" do %>
+  <div class="application__moderation-actions flexbox center">
+    <% if project.project_moderation.reviewed? %>
+      <div class="application__moderation-status <%= project.project_moderation.confirmed_spam? ? "application__moderation-status--alert" : "application__moderation-status--success" %>">
+        <strong>
+          <%= project.project_moderation.confirmed_spam? ? t(".spam") : t(".not-spam") %>
+        </strong>
+        (<%= project.project_moderation.reviewed_by.name %>)
+
+        <%= button_to t(".undo"), undo_project_moderation_path(project), method: :put, class: "application__moderation-button", form_class: "inline-block" %>
+      </div>
+    <% else %>
+      <% if project.project_moderation&.triggered&.any? %>
+        <%= tag.i(class: "icon-question-sign application__moderation-signals", title: t(".spam-signals", signals: project.project_moderation.triggered.join(', '))) %>
+      <% end %>
+      <%= button_to confirm_spam_project_moderation_path(project), method: :put, class: "application__moderation-button spam-action" do %>
+        <%= tag.i(class: "icon-remove-sign") %> <%= t(".spam") %>
+      <% end %>
+      <%= button_to confirm_legit_project_moderation_path(project), method: :put, class: "application__moderation-button legit-action" do %>
+        <%= t(".not-spam") %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -1,8 +1,8 @@
 <article class="project <%= "shortlisted" if project.shortlisted_by?(current_user) %> <%= "winner" if project.winner? %>" id="project<%= project.id %>" data-id="<%= project.id %>" data-controller="jump" data-jump-scroll-value="<%= local_assigns[:scroll] == true %>">
   <% if !project.hidden? || @display_project_even_if_hidden %>
-    <%= render "projects/project_details", project: project %>
+    <%= render "projects/project_details", project: project, moderation: local_assigns[:moderation] %>
   <% else %>
-    <%= render "projects/project_hidden", project: project %>
+    <%= render "projects/project_hidden", project: project, moderation: local_assigns[:moderation] %>
   <% end %>
 
   <%= render "projects/hide_form", project: project %>

--- a/app/views/projects/_project_details.html.erb
+++ b/app/views/projects/_project_details.html.erb
@@ -2,18 +2,22 @@
   <div class="title">
     <%= link_to project.title, chapter_project_path(project.chapter, project), :class => "title" %>
 
+    <% if local_assigns[:moderation].present? && project.project_moderation %>
+      <%= render "projects/moderation", project: project %>
+    <% else %>
     <div class="actions">
-    <% if project.shortlisted_by?(current_user) %>
-      <%= link_to I18n.t(".awesome", scope: "projects.project", count: 1), project_vote_path(project), :method => :delete, :remote => true, :class => "short-list", data: { chapter: "" } %>
-    <% end %>
-    <% voting_chapters.each do |voting_chapter| %>
-      <%= link_to I18n.t(".awesome", scope: "projects.project", count: voting_chapters.size, chapter: voting_chapter.slug), project_vote_path(project, chapter_id: voting_chapter.id), :method => :post, :remote => true, :class => "short-list", data: { chapter: voting_chapter.id } %>
-    <% end %>
+      <% if project.shortlisted_by?(current_user) %>
+        <%= link_to I18n.t(".awesome", scope: "projects.project", count: 1), project_vote_path(project), :method => :delete, :remote => true, :class => "short-list", data: { chapter: "" } %>
+      <% end %>
+      <% voting_chapters.each do |voting_chapter| %>
+        <%= link_to I18n.t(".awesome", scope: "projects.project", count: voting_chapters.size, chapter: voting_chapter.slug), project_vote_path(project, chapter_id: voting_chapter.id), :method => :post, :remote => true, :class => "short-list", data: { chapter: voting_chapter.id } %>
+      <% end %>
 
-    <% if display_project_actions?(current_user, project) %>
-      <%= link_to '<i class="icon-gear"></i>'.html_safe, "#", class: "project-actions-toggle", data: { action: "click->toggler#toggle" } %>
-    <% end %>
+      <% if display_project_actions?(current_user, project) %>
+        <%= link_to '<i class="icon-gear"></i>'.html_safe, "#", class: "project-actions-toggle", data: { action: "click->toggler#toggle" } %>
+      <% end %>
     </div>
+    <% end %>
 
     <div class="public-link">
       <%= link_to funded_project_path(project), target: "blank" do %>
@@ -60,6 +64,7 @@
             <%= link_to project_path(project), :method => :delete, :data => { :confirm => I18n.t("projects.project.confirm-delete") }, :class => "text-muted delete-spam" do %>
               <i class="icon-li icon-remove"></i> <%= t("projects.project.delete") %>
             <% end %>
+          </li>
         <% end %>
       </ul>
     </section>

--- a/app/views/projects/_project_hidden.html.erb
+++ b/app/views/projects/_project_hidden.html.erb
@@ -1,6 +1,9 @@
 <header>
   <div class="title">
     <%= link_to project.title, chapter_project_path(project.chapter, project), :class => "title" %>
+    <% if local_assigns[:moderation].present? && project.project_moderation %>
+      <%= render "projects/moderation", project: project %>
+    <% end %>
   </div>
 
   <section class="meta-data">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -7,6 +7,14 @@
 
 <section class="applications">
   <h1><%= t ".title", name:  @chapter.display_name, count: @projects.count %></h1>
+
+  <% if @moderation_count&.positive? && current_user.can_moderate_for?(@chapter) %>
+    <div class="application__moderation-notice notice flexbox justify-space-between center">
+      <strong><%= t(".held-for-review", count: @moderation_count) %></strong>
+      <%= link_to t(".review-now"), chapter_moderations_path(@chapter), class: "application__moderation-button" %>
+    </div>
+  <% end %>
+
   <section class="application-filters flexbox vertical">
     <nav>
       <%= link_to '#', :class => 'chapter-selection' do %>
@@ -30,7 +38,7 @@
         <%= check_box_tag "funded", nil, params[:funded].present? %>
         <%= label_tag "funded", t(".funded-filter") %>
       </div>
-      
+
       <div>
         <div class="input string optional date-range">
           <label class="string optional" for="filter_start"><%= t ".start-date" %></label>
@@ -52,9 +60,10 @@
           <span class="icon-search"></span>
         </button>
       </div>
-      
+
     </form>
   </section>
+
   <p class="exports">
     <%= link_to t('.export-projects'), params.permit!.merge(format: :csv, only_path: true) %>
     <% if current_user.admin? %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -18,6 +18,7 @@
     <li><%= link_to t(".invite-trustee"), new_invitation_path %></li>
   <% end %>
 
+  <% if chapter.present? %>
   <li class="section-title">
     <h3><%= chapter.display_name %></h3>
   </li>
@@ -28,6 +29,10 @@
   <% end %>
   <% if current_user.can_manage_chapter?(chapter) %>
     <li><%= link_to t(".edit-chapter-profile"), edit_chapter_path(chapter) %></li>
+  <% end %>
+  <% if current_user.can_moderate_for?(chapter) %>
+    <li><%= link_to t(".project-moderation"), chapter_moderations_path(chapter, filter: :all) %></li>
+  <% end %>
   <% end %>
 
   <% if current_user.admin? || current_user.can_create_chapters? %>
@@ -41,6 +46,7 @@
 
     <% if current_user.admin? %>
       <li><%= link_to t(".view-all-users"), users_path %></li>
+      <li><%= link_to t(".project-moderation"), moderations_path %></li>
     <% end %>
   <% end %>
 </ol>

--- a/config/configs/spam_config.rb
+++ b/config/configs/spam_config.rb
@@ -1,0 +1,17 @@
+class SpamConfig < Anyway::Config
+  attr_config(
+    threshold: 0.85,
+    weight_missing_js_metadata: 0.2,
+    weight_short_time_on_page: 0.3,
+    weight_no_referrer: 0.2,
+    weight_suspicious_user_agent: 0.8,
+    weight_low_form_interactions: 0.4,
+    weight_high_paste_ratio: 0.3,
+    weight_bot_screen_resolution: 0.2,
+    weight_gibberish_fields: 0.5,
+    time_on_page_threshold_ms: 10000,
+    min_form_interactions: 2,
+    gibberish_field_threshold: 3,
+    paste_ratio_threshold: 0.5
+  )
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
       finalists: Finalists
       trustees: Trustees
       members: Members
+      project-moderation: Project Moderation
       create-chapter: Create a Chapter
       invite-trustee: Invite a Trustee
       edit-profile: Edit My Profile
@@ -134,6 +135,20 @@ en:
       feed-title: Recent Posts
       prev-project: Previous Project
       next-project: Next Project
+  moderations:
+    index:
+      moderation: Project Moderation
+      title:
+        one: "%{count} Project for %{name}"
+        other: "%{count} Projects for %{name}"
+      viewing-all-moderated: Viewing all moderated projects
+      moderating-projects:
+        one: Reviewing %{count} moderated project
+        other: Reviewing %{count} moderated projects
+      review-now: Review now
+      back-to-approved-projects: Back to approved projects
+      view-all: view all
+      view-unmoderated-only: view unreviewed only
   passwords:
     create:
       description: You will receive an email within the next few minutes. It contains instructions for changing your password.
@@ -206,8 +221,16 @@ en:
         other: "%{count} Projects for %{name}"
       export-projects: Export Filtered
       export-all-projects: Export All From Date Range
+      held-for-review:
+        one: "%{count} project held for review"
+        other: "%{count} projects held for review"
     show:
       back-to: 'Back to <a href="%{url}">%{name}</a>'
+    moderation:
+      spam: Spam
+      not-spam: Not spam
+      undo: Undo
+      spam-signals: "Spam signals: %{signals}"
   emails:
     invitation:
       subject: "You have been invited to the %{name} chapter of the Awesome Foundation!"
@@ -215,6 +238,7 @@ en:
       subject: "Welcome to the %{name} chapter!"
     application:
       subject: "Thanks for applying!"
+
   sessions:
     new:
       sign-in: Trustee and Dean Sign In

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       resources :projects,  :only => [:index, :show] do
         resource :winner, :only => [:edit]
       end
+      resources :moderations, only: [:index]
       resources :users,     :only => [:index]
     end
 
@@ -60,7 +61,14 @@ Rails.application.routes.draw do
       resources :comments
       resource :winner, :only => [:create, :update, :destroy]
       resource :vote, :only => [:create, :destroy]
+      resource :moderation, :only => [] do
+        put :confirm_spam
+        put :confirm_legit
+        put :undo
+      end
     end
+
+    resources :moderations, only: [:index]
 
     resources :submissions, controller: "projects" do
       collection do

--- a/db/migrate/20251116230500_create_project_moderations.rb
+++ b/db/migrate/20251116230500_create_project_moderations.rb
@@ -1,0 +1,19 @@
+class CreateProjectModerations < ActiveRecord::Migration[7.2]
+  def change
+    create_table :project_moderations do |t|
+      t.references :project, null: false, foreign_key: true
+      t.string :status, null: false, default: "unreviewed"
+      t.string :moderation_type, null: false, default: "spam"
+      t.jsonb :signals, null: false, default: {}
+      t.references :reviewed_by, null: true, foreign_key: { to_table: :users }
+      t.datetime :reviewed_at
+
+      t.timestamps
+    end
+
+    add_index :project_moderations, :status
+    add_index :project_moderations, :moderation_type
+    add_index :project_moderations, :signals, using: :gin
+    # project_id index is automatically created by foreign key
+  end
+end

--- a/spec/controllers/moderations_controller_spec.rb
+++ b/spec/controllers/moderations_controller_spec.rb
@@ -1,0 +1,154 @@
+require 'spec_helper'
+
+describe ModerationsController do
+  let(:chapter) { FactoryBot.create(:chapter) }
+  let(:any_chapter) { Chapter.any_chapter }
+  let(:other_chapter) { FactoryBot.create(:chapter) }
+  let(:project) { FactoryBot.create(:project, chapter: chapter) }
+  let!(:project_moderation) { FactoryBot.create(:project_moderation, project: project) }
+  let(:trustee) { FactoryBot.create(:user_with_trustee_role, chapters: [chapter]) }
+
+  describe "GET #index" do
+    context "when user is admin" do
+      let(:admin) { FactoryBot.create(:admin) }
+
+      before { sign_in_as(admin) }
+
+      it "allows access to any chapter" do
+        get :index, params: { chapter_id: chapter.slug }
+        expect(response).to be_successful
+      end
+
+      it "allows access without chapter scope" do
+        get :index
+        expect(response).to be_successful
+      end
+    end
+
+    context "when user is trustee" do
+      before { sign_in_as(trustee) }
+
+      it "allows access to their chapter" do
+        get :index, params: { chapter_id: chapter.slug }
+        expect(response).to be_successful
+      end
+
+      it "allows access to the Any chapter" do
+        get :index, params: { chapter_id: any_chapter.slug }
+        expect(response).to be_successful
+      end
+
+      it "denies access to other chapters" do
+        get :index, params: { chapter_id: other_chapter.slug }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "denies access without chapter scope" do
+        get :index
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when user is not logged in" do
+      it "redirects to sign in" do
+        get :index
+        expect(response).to redirect_to(sign_in_path)
+      end
+    end
+  end
+
+  describe "POST #confirm_spam" do
+    context "when user is admin" do
+      let(:admin) { FactoryBot.create(:admin) }
+
+      before { sign_in_as(admin) }
+
+      it "allows moderating any project" do
+        post :confirm_spam, params: { project_id: project.id }
+        expect(response).to be_successful
+      end
+    end
+
+    context "when user is a trustee" do
+      before { sign_in_as(trustee) }
+
+      it "allows moderating projects in their chapter" do
+        post :confirm_spam, params: { project_id: project.id }
+        expect(response).to be_successful
+      end
+
+      context "with Any chapter project" do
+        let(:chapter) { Chapter.any_chapter }
+
+        it "allows moderating projects in the Any chapter" do
+          post :confirm_spam, params: { project_id: project.id }
+          expect(response).to be_successful
+        end
+      end
+
+      it "denies moderating projects in other chapters" do
+        other_project = FactoryBot.create(:project, chapter: other_chapter)
+        FactoryBot.create(:project_moderation, project: other_project)
+
+        post :confirm_spam, params: { project_id: other_project.id }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST #confirm_legit" do
+    context "when user is a trustee" do
+      before { sign_in_as(trustee) }
+
+      it "allows moderating projects in their chapter" do
+        post :confirm_legit, params: { project_id: project.id }
+        expect(response).to be_successful
+      end
+
+      context "with Any chapter project" do
+        let(:chapter) { Chapter.any_chapter }
+
+        it "allows moderating projects in the Any chapter" do
+          post :confirm_legit, params: { project_id: project.id }
+          expect(response).to be_successful
+        end
+      end
+
+      it "denies moderating projects in other chapters" do
+        other_project = FactoryBot.create(:project, chapter: other_chapter)
+        FactoryBot.create(:project_moderation, project: other_project)
+
+        post :confirm_legit, params: { project_id: other_project.id }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST #undo" do
+    context "when user is trustee" do
+      before { sign_in_as(trustee) }
+
+      it "allows undoing moderation for projects in their chapter" do
+        post :undo, params: { project_id: project.id }
+        expect(response).to be_successful
+      end
+
+      context "with Any chapter project" do
+        let(:chapter) { Chapter.any_chapter }
+
+        it "allows undoing moderation for projects in the Any chapter" do
+          post :undo, params: { project_id: project.id }
+          expect(response).to be_successful
+        end
+      end
+
+      it "denies undoing moderation for projects in other chapters" do
+        other_project = FactoryBot.create(:project, chapter: other_chapter)
+        FactoryBot.create(:project_moderation, project: other_project)
+
+        post :undo, params: { project_id: other_project.id }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -117,4 +117,10 @@ FactoryBot.define do
     user
     body { "This is the body of my comment." }
   end
+
+  factory :project_moderation do
+    project
+    status { "suspected" }
+    moderation_type { "spam" }
+  end
 end

--- a/spec/lib/spam_classifier_spec.rb
+++ b/spec/lib/spam_classifier_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe SpamClassifier do
+  let(:metadata) { {} }
+  let(:project) { FactoryBot.create(:project, metadata: metadata) }
+  let(:classifier) { SpamClassifier.new(project) }
+
+  describe "#analyze!" do
+    context "with missing JS metadata" do
+      let(:metadata) { {} }
+
+      before { classifier.analyze! }
+
+      it "adds missing_js_metadata signal" do
+        expect(classifier.signals).to include("missing_js_metadata")
+      end
+
+      it "includes weight in score" do
+        expect(classifier.score).to be >= 0.2
+      end
+    end
+
+    context "with short time on page" do
+      let(:metadata) { { "time_on_page_ms" => 5000, "timezone" => "UTC" } }
+
+      before { classifier.analyze! }
+
+      it "adds short_time_on_page signal" do
+        expect(classifier.signals).to include("short_time_on_page")
+      end
+    end
+
+    context "with suspicious user agent" do
+      let(:metadata) { { "user_agent" => "HeadlessChrome/91.0", "timezone" => "UTC" } }
+
+      before { classifier.analyze! }
+
+      it "adds suspicious_user_agent signal" do
+        expect(classifier.signals).to include("suspicious_user_agent")
+      end
+    end
+
+    context "with gibberish fields" do
+      let(:metadata) { { "timezone" => "UTC" } }
+
+      before do
+        project.update!(name: "kjKSJsa", title: "asdfgh", about_me: "qwerty", about_project: "zxcvbn")
+        classifier.analyze!
+      end
+
+      it "adds gibberish_fields signal" do
+        expect(classifier.signals).to include("gibberish_fields")
+      end
+    end
+
+    context "with high paste ratio" do
+      let(:metadata) { { "keystroke_count" => 10, "paste_count" => 8, "timezone" => "UTC" } }
+
+      before { classifier.analyze! }
+
+      it "adds high_paste_ratio signal" do
+        expect(classifier.signals).to include("high_paste_ratio")
+      end
+    end
+  end
+
+  describe "#suspected_spam?" do
+    context "when score exceeds threshold" do
+      let(:metadata) { { "user_agent" => "bot", "timezone" => "UTC" } }
+
+      it "returns true" do
+        classifier.analyze!
+        expect(classifier.suspected_spam?).to be true
+      end
+    end
+
+    context "when score is below threshold" do
+      let(:metadata) { { "time_on_page_ms" => 30000, "timezone" => "UTC", "referrer" => "https://google.com" } }
+
+      it "returns false" do
+        classifier.analyze!
+        expect(classifier.suspected_spam?).to be false
+      end
+    end
+  end
+
+  describe "#analysis" do
+    let(:metadata) { { "time_on_page_ms" => 5000, "timezone" => "UTC", "referrer" => "https://google.com" } }
+
+    before { classifier.analyze! }
+
+    it "returns score and triggered signals" do
+      result = classifier.analysis
+      expect(result[:score]).to be > 0
+      expect(result[:triggered]).to include("short_time_on_page")
+    end
+  end
+end

--- a/spec/models/project_moderation_spec.rb
+++ b/spec/models/project_moderation_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe ProjectModeration do
+  let(:project) { FactoryBot.create(:project) }
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "validations" do
+    it "validates uniqueness of project_id" do
+      FactoryBot.create(:project_moderation, project: project)
+
+      duplicate_moderation = FactoryBot.build(:project_moderation, project: project)
+      expect(duplicate_moderation).not_to be_valid
+      expect(duplicate_moderation.errors[:project_id]).to include("has already been taken")
+    end
+  end
+  let(:project_moderation) { FactoryBot.create(:project_moderation, project: project) }
+
+  describe "#mark_confirmed_spam!" do
+    it "updates status to confirmed_spam" do
+      project_moderation.mark_confirmed_spam!(user)
+      expect(project_moderation.status).to eq("confirmed_spam")
+    end
+
+    it "sets reviewed_by to the user" do
+      project_moderation.mark_confirmed_spam!(user)
+      expect(project_moderation.reviewed_by).to eq(user)
+    end
+
+    it "sets reviewed_at to current time" do
+      before_time = Time.current
+      project_moderation.mark_confirmed_spam!(user)
+      expect(project_moderation.reviewed_at).to be >= before_time
+    end
+  end
+
+  describe "#mark_confirmed_legit!" do
+    it "updates status to confirmed_legit" do
+      project_moderation.mark_confirmed_legit!(user)
+      expect(project_moderation.status).to eq("confirmed_legit")
+    end
+
+    it "sets reviewed_by to the user" do
+      project_moderation.mark_confirmed_legit!(user)
+      expect(project_moderation.reviewed_by).to eq(user)
+    end
+
+    it "sets reviewed_at to current time" do
+      before_time = Time.current
+      project_moderation.mark_confirmed_legit!(user)
+      expect(project_moderation.reviewed_at).to be >= before_time
+    end
+  end
+
+  describe "#reviewed?" do
+    it "returns true when reviewed_by is present" do
+      project_moderation.update!(reviewed_by: user)
+      expect(project_moderation.reviewed?).to be true
+    end
+
+    it "returns false when reviewed_by is nil" do
+      project_moderation.update!(reviewed_by: nil)
+      expect(project_moderation.reviewed?).to be false
+    end
+  end
+
+  describe "scopes" do
+    let!(:unreviewed) { FactoryBot.create(:project_moderation, status: "unreviewed") }
+    let!(:suspected) { FactoryBot.create(:project_moderation, status: "suspected") }
+    let!(:confirmed_spam) { FactoryBot.create(:project_moderation, status: "confirmed_spam") }
+    let!(:confirmed_legit) { FactoryBot.create(:project_moderation, status: "confirmed_legit") }
+
+    describe ".pending" do
+      it "includes unreviewed and suspected moderations" do
+        expect(ProjectModeration.pending).to contain_exactly(unreviewed, suspected)
+      end
+    end
+
+    describe ".approved" do
+      it "includes only confirmed_legit moderations" do
+        expect(ProjectModeration.approved).to contain_exactly(confirmed_legit)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -156,6 +156,34 @@ describe User do
     end
   end
 
+  context "#can_moderate_for?" do
+    let(:admin) { FactoryBot.create(:admin) }
+    let!(:chapter) { FactoryBot.create(:chapter) }
+    let!(:trustee) { FactoryBot.create(:user_with_trustee_role) }
+    let!(:role) { FactoryBot.create(:role, user: trustee, chapter: chapter) }
+    let(:other_trustee) { FactoryBot.create(:user_with_trustee_role) }
+
+    it "is true for admins" do
+      expect(admin.reload.can_moderate_for?(chapter)).to be true
+    end
+
+    it "is true for a chapter trustee" do
+      expect(trustee.reload.can_moderate_for?(chapter)).to be true
+    end
+
+    it "is true for any trustee with the Any chapter" do
+      expect(trustee.reload.can_moderate_for?(Chapter.any_chapter)).to be true
+    end
+
+    it "is not true for a trustee of another chapter" do
+      expect(other_trustee.reload.can_moderate_for?(chapter)).to be false
+    end
+
+    it "is not true for a trustee when the chapter is nil" do
+      expect(trustee.reload.can_moderate_for?(nil)).to be_falsey
+    end
+  end
+
   context ".deans_first" do
     let(:chapter){ FactoryBot.create(:chapter) }
     let!(:trustee){ FactoryBot.create(:role, :chapter => chapter) }


### PR DESCRIPTION
Add project moderation system for spam review

Enable trustees and admins to review and moderate flagged projects through
a dedicated moderation interface. Suspected spam projects are automatically
flagged based on configurable detection criteria and routed for human review.

- Trustees can moderate projects in their chapters and the Any chapter
- Admins have full moderation access across all chapters
- Projects can be confirmed as spam, marked legitimate, or have decisions undone
- Spam detection weights and thresholds configurable via environment variables
- Real-time moderation actions update interface without page reloads

## Out of scope for this PR

1. Email confirmation should not be sent for projects being held for review (#572)
2. Merge existing SpamCheck checks into SpamClassifier for a unified moderation system (#574)

## Screenshots

Notice on main project dashboard:

<img width="745" height="260" alt="image" src="https://github.com/user-attachments/assets/deb345f8-efa0-4fd9-9910-55ba38f86e56" />

Project being held for moderation with action buttons:

<img width="723" height="396" alt="image" src="https://github.com/user-attachments/assets/62e90d2c-4287-4466-8380-3023c7ffaf3f" />


Moderated project:

<img width="721" height="392" alt="image" src="https://github.com/user-attachments/assets/80e734de-d2bb-4bcd-a569-e8ca2f29f243" />
