### PR TITLE
Project submission confirmation email respects moderation status

### DIFF
--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -1,4 +1,6 @@
 class ModerationsController < ApplicationController
+  CONFIRMATION_EMAIL_DELAY_SECONDS = 10
+
   before_action :require_login
   before_action :find_chapter, only: [:index]
   before_action :find_project_and_chapter, only: [:confirm_spam, :confirm_legit, :undo]
@@ -19,6 +21,10 @@ class ModerationsController < ApplicationController
 
   def confirm_legit
     @project.project_moderation&.mark_confirmed_legit!(current_user)
+
+    # Send the application confirmation email with a delay to allow for the undo
+    ProjectMailerJob.perform_in(CONFIRMATION_EMAIL_DELAY_SECONDS, @project.id)
+
     render partial: "projects/moderation", locals: {project: @project}
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -71,6 +71,9 @@ class ProjectsController < ApplicationController
       flash[:notice] = t("flash.applications.error")
       render :new
     elsif @project.save
+      # Send the application confirmation email
+      ProjectMailerJob.perform_async(@project.id)
+
       redirect_to success_submissions_path({ chapter: @project.chapter, mode: params[:mode] }.reject { |_, v| v.blank? })
     else
       flash.now[:notice] = t("flash.applications.error")

--- a/app/jobs/project_mailer_job.rb
+++ b/app/jobs/project_mailer_job.rb
@@ -1,9 +1,16 @@
 class ProjectMailerJob
   include SuckerPunch::Job
 
-  def perform(project)
+  def perform(project_id)
     ActiveRecord::Base.connection_pool.with_connection do
-      project.mailer.new_application(project).deliver_now
+      project = Project.find_by(id: project_id)
+      return unless project
+
+      if project.not_pending_moderation?
+        project.mailer.new_application(project).deliver_now
+      else
+        Rails.logger.info "SUSPECTED SPAM: Project #{project.id} pending moderation - new_application mail not sent"
+      end
     end
   end
 end

--- a/spec/controllers/moderations_controller_spec.rb
+++ b/spec/controllers/moderations_controller_spec.rb
@@ -97,12 +97,18 @@ describe ModerationsController do
   end
 
   describe "POST #confirm_legit" do
+    let(:fake_mailer) { FakeMailer.new }
+
     context "when user is a trustee" do
-      before { sign_in_as(trustee) }
+      before do
+        sign_in_as(trustee)
+        Project.any_instance.stubs(:mailer).returns(fake_mailer)
+      end
 
       it "allows moderating projects in their chapter" do
         post :confirm_legit, params: { project_id: project.id }
         expect(response).to be_successful
+        expect(fake_mailer).to have_delivered_email(:new_application)
       end
 
       context "with Any chapter project" do
@@ -111,6 +117,7 @@ describe ModerationsController do
         it "allows moderating projects in the Any chapter" do
           post :confirm_legit, params: { project_id: project.id }
           expect(response).to be_successful
+          expect(fake_mailer).to have_delivered_email(:new_application)
         end
       end
 
@@ -120,6 +127,7 @@ describe ModerationsController do
 
         post :confirm_legit, params: { project_id: other_project.id }
         expect(response).to have_http_status(:not_found)
+        expect(fake_mailer).to_not have_delivered_email(:new_application)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -13,18 +13,6 @@ describe Project do
   it { is_expected.to have_many(:users).through(:votes) }
   it { is_expected.to have_many(:photos) }
 
-  context '#save' do
-    let(:fake_mailer) { FakeMailer.new }
-    let(:chapter) { FactoryBot.create(:chapter) }
-    let(:project) { FactoryBot.build(:project, chapter: chapter) }
-
-    it 'sends an email to the applicant on successful save' do
-      project.mailer = fake_mailer
-      project.save
-      expect(fake_mailer).to have_delivered_email(:new_application)
-    end
-  end
-
   context '#chapter_name' do
     let(:chapter) { FactoryBot.create :chapter, :name => 'Test chapter' }
     let(:project) { FactoryBot.create :project, :chapter => chapter }


### PR DESCRIPTION
Move email sending from Project after_create into the models. This allows for better control and is just cleaner (there might be times when we want to create a project without actually sending an email, for import purposes for example).

* Send email immediately if the project is not held for moderation
* Send email if a project is marked as legit, but add a delay to give the moderator a chance to undo their decision

This is a follow-up to https://github.com/awesomefoundation/awesomebits/pull/571