### PR TITLE
Chapter page trustee list on mobile always shows trustee name; trustees only link if URL is set

### DIFF
--- a/app/assets/stylesheets/_chapters-show.scss
+++ b/app/assets/stylesheets/_chapters-show.scss
@@ -29,8 +29,8 @@ body.chapters-show {
 
       .title {
         margin-right: 1.5em;
-        margin-left: 1.5em;      
-        border-bottom: 1px solid rgb(200,200,200); 
+        margin-left: 1.5em;
+        border-bottom: 1px solid rgb(200,200,200);
         padding-bottom: 10px;
 
         h1 {
@@ -96,7 +96,7 @@ body.chapters-show {
       }
     }
   }
-  
+
   .owl-stage {
     margin: 0 auto;
   }
@@ -157,7 +157,7 @@ body.chapters-show {
       opacity: 1;
     }
   }
-  
+
   .chapter-projects.touch-device {
       .owl-nav-round button {
         display: none !important;
@@ -208,7 +208,7 @@ body.chapters-show {
     }
   }
 
-  
+
   .chapter-projects {
     white-space: nowrap;
     overflow: hidden;
@@ -287,7 +287,7 @@ body.chapters-show {
     border-bottom: 1px solid rgb(200,200,200);
   }
 
-  .trustees {    
+  .trustees {
     padding-bottom: 40px;
     margin-left: 1.5em;
     margin-right: 1.5em;
@@ -298,7 +298,7 @@ body.chapters-show {
       border-bottom: 1px solid rgb(200,200,200);
       padding-bottom: 15px;
     }
-    
+
     ol {
       @extend .clearfix;
       margin: 0px;
@@ -326,7 +326,6 @@ body.chapters-show {
         article.trustee {
           position: relative;
 
-          a {
             text-decoration: none;
 
             div.avatar {
@@ -341,7 +340,7 @@ body.chapters-show {
               opacity: 0;
               padding: 8px;
               position: absolute;
-              top: 80px;
+              top: 100px;
               max-width: grid-width(2);
               z-index: 3;
 
@@ -368,24 +367,20 @@ body.chapters-show {
                 opacity: 1;
               }
             }
-          }
+
         }
 
         &:nth-child(even) {
-          a:hover {
-            .trustee-details {
-              left: -4px;
-              @include transform(rotate(-10deg));
-            }
+          .trustee-details {
+            left: -4px;
+            @include transform(rotate(-10deg));
           }
         }
 
         &:nth-child(odd) {
-          a:hover {
-            .trustee-details {
-              left: -12px;
-              @include transform(rotate(7deg));
-            }
+          .trustee-details {
+            left: -12px;
+            @include transform(rotate(7deg));
           }
         }
       }
@@ -483,11 +478,25 @@ body.chapters-show {
 /*               Responsiveness               */
 /**********************************************/
 
+@media (hover: none) {
+  .chapter-info {
+    .trustees {
+      ol {
+        li article.trustee {
+          .trustee-details {
+            opacity: 1;
+          }
+        }
+      }
+    }
+  }
+}
+
 @media (max-width:31.1em) {
   .chapter-info {
     .trustees {
       ol {
-        li {          
+        li {
           transform: scale(0.9);
         }
       }

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -82,15 +82,16 @@
         <% @chapter.users.deans_first.including_role.distinct.each do |user| %>
         <li>
           <article class="trustee <%= user.role %>">
-            <%= link_to user.url, :class => :avatar do %>
+            <% trustee_html = capture do %>
               <div class="hat"></div>
               <div class="trustee-details">
-                <h3><%= user.first_name %> <%= user.last_name %></h3>
+                <h3><%= user.first_name %> <%= user.last_name %><%= "&nbsp;➚".html_safe if user.url.present? %></h3>
               </div>
               <div class="avatar">
                 <%= image_tag user.gravatar_url, :alt => t(".trustees.photo-alt-text", :name => user.name) %>
               </div>
             <% end %>
+            <%= link_to_if user.url.present?, trustee_html, user.url, { target: "_blank", class: :avatar } %>
           </article>
         </li>
         <% end %>
@@ -107,7 +108,7 @@
       </div>
     </section>
   <% end %>
-  
+
 </div>
 
 <% content_for :javascript do -%>


### PR DESCRIPTION
1. It's currently very awkward to try to see a trustee's name on mobile because the names only show up on hover and there is no "hover" state on mobile. The solution here is to always show the names in mobile view. 
2. If a trustee does not have a custom URL set, don't make their name a link - currently everyone's avatar is a link, but if there is no custom URL set, it just links back to the current chapter page, which is confusing behavior.